### PR TITLE
feat: three-line diary backend v1 (OAuth + Diary + Comment + Validation + User + Refresh)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,46 @@
+# Project Configuration
+COMPOSE_PROJECT_NAME=language-dev
+
+# MongoDB Configuration
+MONGO_INITDB_ROOT_USERNAME=your_mongo_username
+MONGO_INITDB_ROOT_PASSWORD=your_mongo_password
+MONGO_DATABASE=your_database_name
+
+# Redis Configuration
+REDIS_PASSWORD=your_redis_password
+
+# MySQL Configuration
+MYSQL_PORT=3306
+MYSQL_ROOT_PASSWORD=root
+MYSQL_DATABASE=language_db
+MYSQL_USER=language_user
+MYSQL_PASSWORD=language_password
+
+# Kafka Configuration
+KAFKA_PORT=9092
+KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
+
+# Zookeeper Configuration
+ZOOKEEPER_CLIENT_PORT=2181
+ZOOKEEPER_TICK_TIME=2000
+
+# Port Configuration
+ZOOKEEPER_PORT=2181
+MONGODB_PORT=27017
+REDIS_PORT=6379
+
+# Application URLs
+FRONTEND_BASE_URL=http://localhost:3000
+BACKEND_BASE_URL=http://localhost:8080
+
+# OAuth - Kakao
+KAKAO_CLIENT_ID=
+KAKAO_CLIENT_SECRET=
+
+# OAuth - Naver
+NAVER_CLIENT_ID=
+NAVER_CLIENT_SECRET=
+
+# OAuth - Google
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 1단계: 빌드 (JDK 필요)
-FROM eclipse-temurin:17-jdk-jammy AS builder
+FROM eclipse-temurin:21-jdk-jammy AS builder
 WORKDIR /app
 
 # Scouter Agent 다운로드 (버전은 최신으로 조정 가능)
@@ -18,7 +18,7 @@ RUN chmod +x gradlew
 RUN ./gradlew bootJar --no-daemon
 
 # 2단계: 실행 (실행 시에는 JRE만 있어도 충분하여 용량이 줄어듭니다)
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 WORKDIR /app
 ENV TZ=Asia/Seoul
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ version = "0.0.1-SNAPSHOT"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 
@@ -102,6 +102,8 @@ dependencies {
     // Database
     runtimeOnly("com.h2database:h2")
     runtimeOnly("com.mysql:mysql-connector-j")
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-mysql")
 
     //json
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/docs/adr/0001-oauth-token-delivery-pattern.md
+++ b/docs/adr/0001-oauth-token-delivery-pattern.md
@@ -1,0 +1,117 @@
+---
+id: ADR-0001
+title: OAuth 콜백 토큰 전달 패턴
+status: Accepted
+date: 2026-04-24
+deciders: jonghuncu@gmail.com
+related-prd: ../prd/oauth-social-login.md
+---
+
+# ADR 0001 — OAuth 콜백 토큰 전달 패턴
+
+## 상태
+
+Accepted (2026-04-24)
+
+## 컨텍스트
+
+`language` 백엔드는 현재 이메일/비밀번호 기반 회원가입·로그인만 제공하며, JWT access token 을
+`Authorization: Bearer ...` 헤더로 검증한다 (`system/security/JwtUtil.kt`, `JwtAuthorizationFilter.kt`).
+
+신규로 카카오·네이버 소셜 로그인을 추가한다. 외부 provider 의 표준 OAuth 2.0 Authorization
+Code Grant 흐름을 따르되, **콜백 이후 백엔드가 발급한 JWT 를 클라이언트에 어떻게 전달할
+것인가** 를 결정해야 한다.
+
+제약:
+
+- **현재 클라이언트는 웹만**, **향후 모바일(Flutter 추정) 추가 예정**. 단일 백엔드가 두 클라이언트를
+  모두 지원해야 한다.
+- 기존 인증은 Bearer 헤더 표준이며, 클라이언트도 이 패턴을 따르고 있다.
+- Refresh token 은 이미 도메인 모델 (`domain/user/RefreshToken.kt`) 과 저장소
+  (`infrastructure/user/UserRefreshTokenRepository.kt`) 가 존재한다.
+- 운영 환경에 Redis 는 도입되어 있지 않다. Kafka 는 사용 중.
+
+## 결정
+
+**(c) Authorization Code Exchange 패턴을 채택한다.**
+
+OAuth 콜백을 처리한 백엔드는 JWT 를 직접 redirect URL 에 싣지 않고, **1회용 단명(short-lived)
+authorization code** 만 프론트엔드 redirect URL 에 부착한다. 클라이언트는 별도 endpoint
+(`POST /api/v1/auth/exchange`) 에 code 를 제출하여 access/refresh 토큰을 응답 body 로
+수령한다.
+
+```
+provider callback → backend issues code → 302 redirect (?code=...)
+                                       → client POST /auth/exchange {code}
+                                       → 200 {accessToken, refreshToken, ...}
+```
+
+## 검토한 대안
+
+### (a) HttpOnly Cookie
+
+콜백 응답에 `Set-Cookie` 로 access token 쿠키를 굽고, 이후 모든 요청에 브라우저가 자동
+첨부.
+
+- ✅ XSS 시 토큰 탈취 불가 (JS 가 `document.cookie` 로 못 읽음).
+- ✅ 클라이언트가 토큰 처리 코드를 작성할 필요 없음.
+- ❌ **모바일 합류 시 재작업.** Flutter `Dio` 는 cookie jar 를 별도 설정해야 하고, 기존
+  Bearer 표준과 충돌한다.
+- ❌ Cross-origin (FE 와 API 도메인 분리) 시 `SameSite=None; Secure` + CORS
+  `credentials: include` 등 설정 부담.
+- ❌ CSRF 방어 별도 필요.
+
+### (b) URL Query Param JWT
+
+`/auth/callback?accessToken=...&refreshToken=...` 로 redirect.
+
+- ✅ 구현 가장 단순.
+- ❌ **RFC 9700 §4.3.2 가 명시적으로 금지.** 다음 경로로 토큰이 유출된다:
+  - 브라우저 히스토리 / 세션 복원
+  - Referer 헤더 (콜백 페이지가 외부 리소스 로드 시)
+  - 서버/CDN/리버스 프록시 access log
+  - 사용자 URL 공유 사고
+- ❌ Production 권장 사례 부재.
+
+### (c) Code Exchange — **채택**
+
+- ✅ 토큰이 URL/히스토리/Referer/로그 어디에도 노출되지 않는다 (1회용 code 만 노출).
+- ✅ 웹·모바일이 **완전히 동일한 endpoint** 를 사용한다. 모바일 합류 시 백엔드 변경 0.
+- ✅ OAuth 2.0 Authorization Code Grant 의 표준 흐름과 동형 — 검증된 모델.
+- ✅ 기존 Bearer 인증 인프라 (`JwtUtil`, `JwtAuthorizationFilter`) 를 그대로 재사용.
+- ⚠️ 1회용 code 저장소 필요. 단계 1 은 in-memory `ConcurrentHashMap` 으로 시작하고,
+  다중 인스턴스 운영 시점에 Redis 로 교체 (PRD §11 참조).
+- ⚠️ 클라이언트가 토큰을 보관하므로 XSS 위험은 (a) 보다 크다. 단계 2 에서
+  refresh token 만 HttpOnly cookie 로 분리하는 하이브리드 보강 가능 (Open Question).
+
+## 결과 (Consequences)
+
+### 긍정
+
+- 웹·모바일 통합 인증 백엔드 1세트로 운영 가능.
+- 토큰 노출면 최소화 (URL/로그/Referer 무영향).
+- OAuth 표준 흐름이라 외부 감사(audit) 시 설명 비용 낮음.
+- 기존 JWT 인프라 재사용으로 변경 범위가 OAuth 신규 코드에 한정됨.
+
+### 부정
+
+- HTTP 왕복 1회 추가 (callback → frontend → exchange).
+- AuthCodeStore 라는 신규 추상화와 그 구현체(메모리 → Redis) 운영 책임.
+- 클라이언트가 access token 을 메모리/저장소에 보관해야 하므로 XSS 방어가 클라이언트의
+  책임으로 남는다 (CSP, 의존 라이브러리 검수 등).
+
+### 위험 / 완화책
+
+| 위험 | 완화책 |
+|---|---|
+| in-memory code store 는 다중 인스턴스에서 일관성 깨짐 | 단계 1 단일 인스턴스 한정. 멀티 인스턴스 전 Redis 도입을 PRD 단계 2 로 못 박음. |
+| code 재사용 공격 | `consume()` 은 원자적 (메모리 단계: `ConcurrentHashMap.remove`, Redis 단계: `GETDEL`). TTL 60s. |
+| code 추측 공격 | UUID v4 (122-bit 무작위), TTL 짧음 → 무차별 공간 무의미. |
+| XSS 로 access token 탈취 | access TTL 짧게 (1h), refresh rotation, 클라이언트 CSP 강화. 단계 2 에서 refresh-only HttpOnly cookie 하이브리드 검토. |
+| provider 응답에 email scope 미포함 | `OAUTH_EMAIL_REQUIRED` 로 사용자 친화 에러. 동의 재요청 유도. |
+
+## 참고
+
+- OAuth 2.0 Security Best Current Practice (RFC 9700, 2025) §4.3.2 — URL query 에 토큰 금지.
+- OAuth 2.0 for Browser-Based Apps (IETF draft, BCP 후보) — SPA 토큰 처리 가이드라인.
+- RFC 8252 — OAuth 2.0 for Native Apps (모바일 합류 단계에서 PKCE 도입 시 참조).

--- a/docs/prd/oauth-social-login.md
+++ b/docs/prd/oauth-social-login.md
@@ -1,0 +1,559 @@
+---
+id: PRD-oauth-social-login
+title: OAuth 소셜 로그인 (Kakao, Naver)
+status: Draft
+owner: jonghuncu@gmail.com
+created: 2026-04-24
+updated: 2026-04-24
+related-adr: ../adr/0001-oauth-token-delivery-pattern.md
+---
+
+# PRD — OAuth 소셜 로그인 (Kakao, Naver)
+
+> **읽기 전 필수**: 본 PRD 의 토큰 전달 방식 결정 근거는 `docs/adr/0001-oauth-token-delivery-pattern.md`
+> 에 별도 ADR 로 분리되어 있다. 구현 전 ADR 을 먼저 읽고 결정의 트레이드오프를 숙지할 것.
+
+---
+
+## 1. 목표
+
+- 카카오·네이버 OAuth 2.0 Authorization Code Grant 기반 소셜 로그인을 신규 도입한다.
+- 백엔드는 콜백 후 **1회용 authorization code** 만 프론트로 전달하고, 별도 교환 endpoint
+  로 access/refresh JWT 를 응답한다 (ADR-0001 결정).
+- 모든 인증된 API 호출은 기존과 동일하게 `Authorization: Bearer ...` 표준을 따른다.
+- 기존 이메일 가입 사용자(`User`) 모델을 확장 재사용한다 (별도 테이블/Aggregate 분리하지
+  않음).
+
+## 2. 비목표
+
+- 카카오·네이버 외 provider (Google, Apple 등) — 후속 PRD.
+- 소셜 계정 연결/해제(Link/Unlink) UI/UX — 단계 2.
+- BFF 패턴 또는 HttpOnly 세션 쿠키 도입.
+- Refresh token rotation 의 탈취 탐지(reuse detection) 정책 — 단계 2.
+- Mobile-specific callback URL (custom scheme / App Link) 화이트리스트 — 모바일 앱 합류
+  직전 별도 PRD 로 다룬다.
+
+## 3. 배경
+
+`language` 백엔드는 현재 이메일 + 비밀번호 가입/로그인만 지원한다. 사용자 진입 장벽을
+낮추기 위해 국내 사용자 점유율이 높은 카카오·네이버 OAuth 를 추가한다.
+
+현 인증 인프라:
+
+- `system/security/JwtUtil.kt` — JWT 생성/검증.
+- `system/security/JwtAuthorizationFilter.kt` — Bearer 토큰 인증 필터.
+- `domain/user/User.kt` — JPA `@Entity`. (본 프로젝트는 도메인에 JPA 어노테이션을 직접
+  부착하는 규약을 사용한다 — kidsinsightlab 의 strict DDD 와 다름.)
+- `domain/user/RefreshToken.kt` + `infrastructure/user/UserRefreshTokenRepository.kt`.
+- Reader/Writer 패턴: 도메인 인터페이스 → 인프라 구현 (`UserReader`/`UserReaderImpl`).
+- 응용 계층: `application/user/UserFacade.kt` 와 같은 Facade.
+- 컨트롤러: `interfaces/user/UserApiController.kt` 등 `interfaces/{domain}/` 위치.
+
+본 PRD 는 위 규약을 그대로 따른다.
+
+## 4. 사용자 시나리오
+
+1. **신규 소셜 가입**: 사용자가 웹에서 "카카오로 시작하기" 클릭 → 카카오 로그인 페이지 →
+   동의 → 앱으로 복귀 → 자동 가입 + 즉시 로그인 상태.
+2. **기존 소셜 로그인**: 이미 카카오로 가입한 사용자가 동일 흐름으로 로그인. 신규 가입
+   처리 없음.
+3. **이메일 충돌**: 이미 이메일 `foo@bar.com` 으로 LOCAL 가입한 사용자가 동일 이메일을
+   가진 카카오 계정으로 로그인 시도. **거부** (`OAUTH_EMAIL_CONFLICT`) — 자동 연결은
+   피싱 위험으로 단계 1 에서 금지. 사용자에게 "기존 이메일 로그인 사용" 안내.
+4. **provider 동의 항목 누락**: 사용자가 이메일 제공에 동의하지 않음 → `OAUTH_EMAIL_REQUIRED`
+   에러로 동의 재요청 유도.
+5. **로그아웃**: 클라이언트가 `POST /api/v1/auth/logout` 호출 → 서버는 refresh token
+   무효화. access token 은 짧은 TTL 로 자연 만료.
+
+## 5. 흐름
+
+```
+[Web]                          [Backend]                   [Provider]
+  |--GET /api/v1/auth/oauth/{p}/start-->|                     |
+  |   <302 Location + state cookie>     |                     |
+  |--------- authorize ---------------------------------->    |
+  |<--------- 302 callback?code&state -----------------------|
+  |--GET /api/v1/auth/oauth/{p}/callback?code&state-->|      |
+  |                                  |--state 쿠키 검증     |
+  |                                  |--POST token---------->|
+  |                                  |<---access_token-------|
+  |                                  |--GET userinfo-------->|
+  |                                  |<---profile------------|
+  |                                  |--User upsert (DB)     |
+  |                                  |--JWT 발급(access+ref) |
+  |                                  |--AuthCode 저장 (TTL=60s) |
+  |   <302 ${frontend}/auth/callback?code=AUTH_CODE>         |
+  |--POST /api/v1/auth/exchange {code}->|                    |
+  |                                  |--code consume(atomic) |
+  |   <200 {accessToken,refreshToken,tokenType,expiresIn}>   |
+  |                                                           |
+  |--이후 모든 호출: Authorization: Bearer <access>           |
+```
+
+실패 분기:
+
+- provider 가 `error` 반환 / code 누락 → `302 ${frontend}/auth/error?code=OAUTH_AUTHORIZATION_FAILED`
+- state 쿠키 누락/불일치 → `302 ${frontend}/auth/error?code=OAUTH_STATE_INVALID`
+- userinfo 에 email 없음 → `302 ${frontend}/auth/error?code=OAUTH_EMAIL_REQUIRED`
+- 이메일 충돌 → `302 ${frontend}/auth/error?code=OAUTH_EMAIL_CONFLICT`
+- provider 5xx/timeout → `302 ${frontend}/auth/error?code=OAUTH_PROVIDER_ERROR`
+- exchange 시 code 만료/재사용 → `400 OAUTH_CODE_INVALID`
+
+## 6. 기능 요구사항 (FR)
+
+| FR# | 내용 |
+|---|---|
+| FR-1 | `GET /api/v1/auth/oauth/{provider}/start` — provider 인증 페이지로 302. state 쿠키 발급. |
+| FR-2 | `GET /api/v1/auth/oauth/{provider}/callback` — code/state 검증, provider 토큰·userinfo 호출, User upsert, JWT 발급, 1회용 code 발급, frontend 로 302. |
+| FR-3 | `POST /api/v1/auth/exchange` — 1회용 code → access/refresh JWT 응답. |
+| FR-4 | `User` 도메인에 provider 식별자 필드 추가 (`provider`, `providerExternalId`). |
+| FR-5 | 신규 OAuth 가입 시 `User` 자동 생성 (email, username, provider, providerExternalId, role=USER). |
+| FR-6 | 기존 (provider, externalId) 매치 시 재로그인 처리. displayName 변경 시 update. |
+| FR-7 | 이메일 충돌 시 `OAUTH_EMAIL_CONFLICT` 거부. |
+| FR-8 | provider userinfo 에 email 누락 시 `OAUTH_EMAIL_REQUIRED` 거부. |
+| FR-9 | state 쿠키 검증 (CSRF 방어). 쿠키 TTL 5분. |
+| FR-10 | AuthCode TTL 60초, 1회 consume 후 즉시 삭제 (원자적). |
+| FR-11 | `POST /api/v1/auth/logout` — 인증 사용자의 refresh token 삭제. |
+| FR-12 | provider 호출 타임아웃 (connect 5s, read 10s). 실패 시 `OAUTH_PROVIDER_ERROR`. |
+| FR-13 | provider properties 검증 — 누락 시 startup 실패 (`OAUTH_CONFIGURATION_MISSING`). |
+
+## 7. 환경 설정 (`application.yml`)
+
+```yaml
+app:
+  frontend-base-url: ${FRONTEND_BASE_URL:http://localhost:3000}
+  backend-base-url:  ${BACKEND_BASE_URL:http://localhost:8080}
+  jwt:
+    secret: ${JWT_SECRET}                       # 기존 사용 — 변경 없음
+    access-token-ttl: PT1H                      # (신규) 명시적 TTL 추가 — JwtUtil 의 5d 상수 대체 검토
+    refresh-token-ttl: P14D
+  auth:
+    auth-code:
+      ttl: PT60S
+    oauth:
+      kakao:
+        client-id: ${KAKAO_CLIENT_ID}
+        client-secret: ${KAKAO_CLIENT_SECRET}
+        redirect-uri: ${app.backend-base-url}/api/v1/auth/oauth/kakao/callback
+        authorize-uri: https://kauth.kakao.com/oauth/authorize
+        token-uri: https://kauth.kakao.com/oauth/token
+        user-info-uri: https://kapi.kakao.com/v2/user/me
+        scope: account_email profile_nickname
+      naver:
+        client-id: ${NAVER_CLIENT_ID}
+        client-secret: ${NAVER_CLIENT_SECRET}
+        redirect-uri: ${app.backend-base-url}/api/v1/auth/oauth/naver/callback
+        authorize-uri: https://nid.naver.com/oauth2.0/authorize
+        token-uri: https://nid.naver.com/oauth2.0/token
+        user-info-uri: https://openapi.naver.com/v1/nid/me
+        scope: name email
+```
+
+- 모든 secret 은 환경변수. `.env.local` / `.env.example` 에 키만 추가 (값 비움).
+- redirect-uri 는 provider 콘솔 등록 값과 정확히 일치해야 한다.
+
+## 8. 디렉토리 구조 / 신규 파일 목록
+
+본 프로젝트의 layered 구조와 Reader/Writer/Facade 컨벤션을 따른다.
+
+```
+src/main/kotlin/com/learner/language/
+  domain/user/
+    User.kt                                # [수정] provider, providerExternalId 필드 추가
+    AuthProvider.kt                        # [신규] enum LOCAL, KAKAO, NAVER
+    UserReader.kt                          # [수정] findByProvider(...) 추가
+    UserWriter.kt                          # (변경 없음 — save 재사용)
+  domain/auth/                             # [신규 패키지]
+    OAuthAuthenticationException.kt        # [신규]
+    AuthCode.kt                            # [신규] VO: code, AuthTokenSnapshot, expiresAt
+    AuthTokenSnapshot.kt                   # [신규] code 저장용 토큰 직렬화 형태
+  application/auth/                        # [신규 패키지]
+    OAuthFacade.kt                         # [신규] login(provider, code, state) → authCode
+    AuthExchangeFacade.kt                  # [신규] exchange(code) → AuthTokenResult
+    OAuthCommand.kt                        # [신규] LoginCommand, ExchangeCommand
+    OAuthProviderClient.kt                 # [신규] domain port (provider 추상)
+    OAuthUserInfo.kt                       # [신규] provider 응답 통합 모델
+    AuthCodeStore.kt                       # [신규] port: issue/consume
+    AuthTokenIssuer.kt                     # [신규] port: User → AuthTokenResult
+    AuthTokenResult.kt                     # [신규] accessToken, refreshToken, tokenType, expiresIn
+  infrastructure/auth/                     # [신규 패키지]
+    OAuthProperties.kt                     # [신규] @ConfigurationProperties("app.auth.oauth")
+    AuthCodeProperties.kt                  # [신규] @ConfigurationProperties("app.auth.auth-code")
+    KakaoOAuthProviderClient.kt            # [신규]
+    NaverOAuthProviderClient.kt            # [신규]
+    AbstractOAuthProviderClient.kt         # [신규] 공통 토큰/userinfo 호출
+    KakaoOAuthUserInfo.kt                  # [신규]
+    NaverOAuthUserInfo.kt                  # [신규]
+    InMemoryAuthCodeStore.kt               # [신규] ConcurrentHashMap 기반 (단계 1)
+    JwtAuthTokenIssuer.kt                  # [신규] AuthTokenIssuer 구현, JwtUtil 위임
+  interfaces/auth/                         # [신규 패키지]
+    OAuthBrowserController.kt              # [신규] start, callback
+    AuthExchangeController.kt              # [신규] POST /exchange
+    AuthDto.kt                             # [신규] ExchangeRequest, ExchangeResponse
+    AuthLogoutController.kt                # [신규] POST /logout (별도 분리)
+  system/security/
+    OAuthStateCookieManager.kt             # [신규] state 쿠키 전용 (HttpOnly, SameSite=Lax)
+    SecurityConfig.kt                      # [수정] 신규 endpoint permitAll 등록
+  system/exception/
+    GlobalExceptionHandler.kt              # [수정] OAuth ErrorCode 매핑
+```
+
+테스트는 `src/test/kotlin/.../` 동일 구조.
+
+## 9. 도메인 변경 (`domain/`)
+
+### 9.1 `AuthProvider` enum
+```
+LOCAL, KAKAO, NAVER
+```
+
+### 9.2 `User` 수정
+- 신규 필드:
+  ```kotlin
+  @Enumerated(EnumType.STRING)
+  @Column(name = "provider", nullable = false, length = 20)
+  var provider: AuthProvider = AuthProvider.LOCAL,
+
+  @Column(name = "provider_external_id", length = 100)
+  var providerExternalId: String? = null,
+  ```
+- 기존 `password: UserPassword` 는 LOCAL 전용. OAuth 가입 시에는 사용하지 않는 더미 값
+  허용 여부를 결정 필요 (Open Question Q1).
+- 정적 팩토리 / `UserService` 에 OAuth 신규 가입 메서드 추가
+  (`createOAuthUser(email, username, provider, externalId): User`).
+- 불변식 (애플리케이션 단에서 검증, JPA 레벨 X):
+  - `provider == LOCAL` → `password` 필수
+  - `provider != LOCAL` → `providerExternalId` 필수, `password` 미사용
+
+### 9.3 DB 스키마 변경
+프로젝트가 Flyway/Liquibase 를 도입했는지 PRD 작성 시점에 확인되지 않음 (Open Question
+Q2). 확인 후 둘 중 하나:
+
+- **Flyway 도입되어 있음** → `db/migration/V{n}__add_user_oauth_columns.sql` 생성:
+  ```sql
+  ALTER TABLE "user"
+    ADD COLUMN provider VARCHAR(20) NOT NULL DEFAULT 'LOCAL',
+    ADD COLUMN provider_external_id VARCHAR(100);
+  CREATE UNIQUE INDEX uk_user_provider_external
+    ON "user"(provider, provider_external_id)
+    WHERE provider <> 'LOCAL';
+  ```
+- **`ddl-auto=update` 만 사용 중** → entity 변경만으로 자동 반영. 운영 반영 전 수동
+  ALTER 스크립트 PR 노트에 첨부.
+
+### 9.4 `UserReader` 메서드 추가
+```kotlin
+fun findByProvider(provider: AuthProvider, externalId: String): User?
+```
+구현은 `infrastructure/user/UserReaderImpl.kt` + `UserRepository` (Spring Data JPA)
+에 derived query 추가.
+
+### 9.5 `OAuthAuthenticationException`
+- provider 응답 검증 실패 시 throw. ErrorCode 매핑은 application/interfaces 계층에서.
+
+### 9.6 `AuthCode`, `AuthTokenSnapshot` (도메인 VO)
+- `AuthCode(value: String, snapshot: AuthTokenSnapshot, expiresAt: Instant)`.
+- `AuthTokenSnapshot(accessToken, refreshToken, tokenType, expiresInSeconds)` — code 저장
+  형태이며 외부 노출 시에는 `AuthTokenResult` 로 변환.
+
+## 10. 애플리케이션 계층 (`application/auth/`)
+
+### 10.1 Port — `OAuthProviderClient`
+```kotlin
+interface OAuthProviderClient {
+    fun supports(): AuthProvider
+    fun fetchUserInfo(authorizationCode: String, redirectUri: String): OAuthUserInfo
+}
+```
+Spring 이 `List<OAuthProviderClient>` 를 주입받고 `supports()` 로 lookup.
+
+### 10.2 Port — `OAuthUserInfo`
+```kotlin
+interface OAuthUserInfo {
+    val provider: AuthProvider
+    val externalId: String
+    val email: String
+    val displayName: String
+}
+```
+
+### 10.3 Port — `AuthCodeStore`
+```kotlin
+interface AuthCodeStore {
+    fun issue(snapshot: AuthTokenSnapshot): String         // returns one-time code (UUID)
+    fun consume(code: String): AuthTokenSnapshot?          // atomic remove
+}
+```
+
+### 10.4 Port — `AuthTokenIssuer`
+```kotlin
+interface AuthTokenIssuer {
+    fun issue(user: User): AuthTokenResult
+}
+```
+구현 (`JwtAuthTokenIssuer`) 은 기존 `JwtUtil.createToken(...)` 위임 + refresh token 발급
+(기존 `RefreshToken` 도메인 활용).
+
+### 10.5 `OAuthFacade.login(LoginCommand)`
+입력: `LoginCommand(provider, authorizationCode, state)` (state 검증은 Controller 책임).
+
+처리:
+1. provider lookup → `fetchUserInfo(...)`.
+2. `userReader.findByProvider(provider, externalId)`:
+   - 존재 → displayName 변경 시 update 후 반환.
+   - 없음 → `userReader.findByEmail(email)`:
+     - 존재 (어떤 provider 든) → throw `OAUTH_EMAIL_CONFLICT`.
+     - 없음 → `userService.createOAuthUser(...)` 후 반환.
+3. `authTokenIssuer.issue(user)` → `AuthTokenResult`.
+4. `authCodeStore.issue(AuthTokenSnapshot.of(result))` → `String code`.
+5. 반환: `code`.
+
+### 10.6 `AuthExchangeFacade.exchange(ExchangeCommand)`
+1. `authCodeStore.consume(command.code)` → `null` 이면 throw `OAUTH_CODE_INVALID`.
+2. `AuthTokenSnapshot` → `AuthTokenResult` 변환 후 반환.
+
+원자성: `consume` 단일 호출이 remove + return. 동시 호출 시 1개만 성공.
+
+## 11. 인프라스트럭처 계층 (`infrastructure/auth/`)
+
+### 11.1 `OAuthProperties` (`@ConfigurationProperties("app.auth.oauth")`)
+- `kakao: Provider`, `naver: Provider`.
+- `data class Provider(val clientId, val clientSecret, val redirectUri, val authorizeUri, val tokenUri, val userInfoUri, val scope)`.
+- `@Validated` + `@field:NotBlank`.
+
+### 11.2 `AbstractOAuthProviderClient`
+- Spring 6.1+ `RestClient` 1개 보유. (이미 `spring-boot-starter-web` 사용 중이므로 별도
+  의존성 추가 불필요. WebClient 도 후보지만 `RestClient` 가 동기 호출에 더 단순.)
+- 공통:
+  - `exchangeCodeForToken(code, redirectUri): OAuthAccessTokenResponse`
+    — `application/x-www-form-urlencoded`, grant_type=authorization_code.
+  - `fetchRawUserInfo(accessToken): Map<String, Any?>`.
+- 타임아웃: connect 5s / read 10s (`HttpClient` 기반).
+- 5xx, IOException, 4xx 모두 `OAuthAuthenticationException` 으로 변환.
+
+### 11.3 `KakaoOAuthProviderClient`
+- userinfo 매핑:
+  - `externalId` ← `id` (Long → String)
+  - `email` ← `kakao_account.email`
+  - `displayName` ← `kakao_account.profile.nickname`
+- 동의 항목 미선택 시 email 이 null → `IllegalStateException` → ErrorCode 매핑은
+  application 계층에서 `OAUTH_EMAIL_REQUIRED` 로 변환.
+
+### 11.4 `NaverOAuthProviderClient`
+- userinfo 매핑:
+  - `externalId` ← `response.id`
+  - `email` ← `response.email`
+  - `displayName` ← `response.name`
+- 응답 wrapper `{ resultcode, message, response: {...} }` 처리.
+
+### 11.5 `InMemoryAuthCodeStore` (단계 1)
+- `ConcurrentHashMap<String, Entry>` 기반.
+- `Entry(snapshot, expiresAt: Instant)`.
+- `issue`: UUID v4 → put. UUID 충돌 (사실상 0) 시 1회 재시도.
+- `consume`: `compute` 또는 `remove` 후 expiresAt 체크 (만료면 null 반환).
+- 백그라운드 cleanup: `@Scheduled(fixedRate = 30s)` 로 만료 항목 제거.
+- **운영 단일 인스턴스 한정**. 멀티 인스턴스 전 Redis 교체 (단계 2 마일스톤).
+
+### 11.6 `JwtAuthTokenIssuer`
+- `JwtUtil.createToken(userId, email)` 호출 — 결과 문자열에 `Bearer ` prefix 가 이미
+  포함됨 (기존 동작). `AuthTokenResult.accessToken` 에는 **prefix 제거 후** 저장
+  (응답 body 의 `tokenType` 으로 분리 명시).
+- refresh token: 기존 `domain/user/RefreshToken.kt` + `UserRefreshTokenRepository`
+  활용. 사용자별 1개 정책 / 다중 정책 여부는 기존 코드 컨벤션 확인 후 결정.
+- `expiresInSeconds`: `app.jwt.access-token-ttl` 에서 계산.
+
+## 12. 인터페이스 계층 (`interfaces/auth/`)
+
+### 12.1 `OAuthBrowserController`
+
+`@RestController @RequestMapping("/api/v1/auth/oauth")`
+
+- `GET /{provider}/start` →
+  - state 생성 (UUID), `OAuthStateCookieManager.set(...)`.
+  - `authorize-uri?response_type=code&client_id&redirect_uri&state` 로 302.
+- `GET /{provider}/callback?code&state&error` →
+  1. error/code 누락 → 실패 redirect.
+  2. state 쿠키 검증 → 불일치 시 실패 redirect (`OAUTH_STATE_INVALID`).
+  3. `OAuthFacade.login(...)` → `authCode` 수령.
+  4. 성공 → `302 ${frontend}/auth/callback?code={authCode}` (토큰 미포함).
+  5. 실패 (`BusinessException`) → `302 ${frontend}/auth/error?code={errorCode}`.
+  6. finally: state 쿠키 만료.
+
+### 12.2 `AuthExchangeController`
+
+`@RestController @RequestMapping("/api/v1/auth")`
+
+- `POST /exchange` body `{ "code": "uuid" }` → 200 `{ accessToken, refreshToken, tokenType: "Bearer", expiresIn }`.
+- 실패 400 `{ errorCode: "OAUTH_CODE_INVALID", message }`.
+- 인증 불필요. CORS 허용.
+
+### 12.3 `AuthLogoutController`
+
+`@RestController @RequestMapping("/api/v1/auth")`
+
+- `POST /logout` (`@LoginUser userId: Long`) → refresh token 삭제 → 204.
+
+### 12.4 `AuthDto`
+```kotlin
+object AuthDto {
+    data class ExchangeRequest(@field:NotBlank val code: String) {
+        fun toCommand(): ExchangeCommand = ExchangeCommand(code)
+    }
+    data class ExchangeResponse(
+        val accessToken: String,
+        val refreshToken: String,
+        val tokenType: String,
+        val expiresIn: Long,
+    ) {
+        companion object {
+            fun from(result: AuthTokenResult) = ExchangeResponse(
+                result.accessToken, result.refreshToken, result.tokenType, result.expiresInSeconds,
+            )
+        }
+    }
+}
+```
+
+## 13. 시스템 (`system/`)
+
+### 13.1 `OAuthStateCookieManager` (`system/security/`)
+- `set(response, provider, value)` — HttpOnly, Secure, SameSite=Lax, Path=/, Max-Age=300.
+- `get(request, provider): String?`.
+- `clear(response, provider)`.
+- 쿠키명: `LANGUAGE_OAUTH_STATE_{PROVIDER}`.
+- access token 은 절대 다루지 않는다 (이름 그대로 state 전용).
+
+### 13.2 `SecurityConfig` 수정
+permitAll 에 추가:
+- `GET  /api/v1/auth/oauth/*/start`
+- `GET  /api/v1/auth/oauth/*/callback`
+- `POST /api/v1/auth/exchange`
+
+`POST /api/v1/auth/logout` 은 인증 필요.
+
+CORS: `app.frontend-base-url` origin 화이트리스트. `allowCredentials=false`
+(쿠키 전송 안 함, state 쿠키는 same-site redirect 라 무관).
+
+### 13.3 `JwtAuthorizationFilter` 변경 없음
+- 기존 Bearer 헤더 추출 그대로 동작.
+- 본 PRD 가 새로 도입하는 access token 은 동일 `JwtUtil` 로 생성되므로 기존 필터 검증
+  로직과 호환.
+
+### 13.4 `GlobalExceptionHandler` 수정
+- `BusinessException` (또는 본 프로젝트의 표준 예외) → ErrorCode 의 HTTP status 매핑.
+- `OAuthAuthenticationException` → 502 + `OAUTH_PROVIDER_ERROR` (provider 원문 메시지
+  로그만 남기고 응답에는 노출 금지).
+
+## 14. 에러 코드
+
+기존 ErrorCode enum (또는 이에 상응하는 표준) 에 추가:
+
+| 코드 | HTTP | 의미 |
+|---|---|---|
+| `OAUTH_AUTHORIZATION_FAILED` | 400 | provider 가 error 반환 또는 code 누락 |
+| `OAUTH_STATE_INVALID` | 400 | state 쿠키 누락 또는 불일치 (CSRF 의심) |
+| `OAUTH_PROVIDER_ERROR` | 502 | provider 호출 실패 (5xx, 타임아웃, 4xx) |
+| `OAUTH_EMAIL_REQUIRED` | 400 | provider 가 email scope 미동의 |
+| `OAUTH_EMAIL_CONFLICT` | 409 | 동일 이메일이 다른 가입 경로(LOCAL 또는 다른 provider)로 이미 존재 |
+| `OAUTH_CODE_INVALID` | 400 | exchange 시 code 가 없거나 만료/소비됨 |
+| `OAUTH_CONFIGURATION_MISSING` | 500 | properties 누락 (startup 검증 실패) |
+
+## 15. 테스트 요구사항
+
+### 15.1 도메인 단위 테스트
+- `User` OAuth 신규 가입 팩토리 / 불변식.
+- `AuthProvider` enum.
+
+### 15.2 애플리케이션 단위 테스트 (Mockito 또는 MockK)
+- `OAuthFacade.login`:
+  - 신규 가입 (provider 사용자 없음, 동일 이메일 없음).
+  - 재로그인 (provider+externalId 매치).
+  - displayName 변경 시 update.
+  - LOCAL 사용자 이메일 충돌 → `OAUTH_EMAIL_CONFLICT`.
+  - 다른 provider 이메일 충돌 → `OAUTH_EMAIL_CONFLICT`.
+  - email 누락 → `OAUTH_EMAIL_REQUIRED`.
+- `AuthExchangeFacade.exchange`:
+  - 정상 교환.
+  - 없는 code → `OAUTH_CODE_INVALID`.
+  - 동일 code 동시 2회 호출 시 1회만 성공 (`InMemoryAuthCodeStore` 직접 사용 통합 테스트).
+
+### 15.3 인프라스트럭처 테스트
+- `KakaoOAuthProviderClient`, `NaverOAuthProviderClient` — `MockWebServer` (OkHttp) 또는
+  WireMock 으로 정상/4xx/5xx/타임아웃/이메일 누락 시나리오.
+- `InMemoryAuthCodeStore` — 동시성 (`Awaitility` + `ExecutorService`), TTL 만료, cleanup
+  스케줄러.
+- `@DataJpaTest` — `UserReader.findByProvider`, unique index 검증.
+
+### 15.4 인터페이스 테스트 (`@WebMvcTest`)
+- `OAuthBrowserController`:
+  - `/start` 가 302 + state 쿠키 + Location 헤더.
+  - `/callback` 성공 → Location 이 `${frontend}/auth/callback?code=...`, **응답 본문/헤더 어디에도 토큰 문자열 미포함** 검증.
+  - `/callback` state 불일치 → 실패 redirect.
+- `AuthExchangeController`:
+  - 정상 200 + body 검증.
+  - 없는 code → 400.
+
+### 15.5 통합 테스트 (`@SpringBootTest` + 임베디드 DB)
+- 전체 흐름: `/start` → mock provider → `/callback` → frontend redirect 의 `code` 추출
+  → `/exchange` → 발급된 access token 으로 `/api/v1/users/me` 200.
+
+## 16. 클라이언트 계약 (Web → 향후 Mobile 공통)
+
+별도 클라이언트 PRD/문서로 인계할 핵심 계약:
+
+- **시작**: `GET /api/v1/auth/oauth/{kakao|naver}/start` 로 브라우저 location 이동.
+- **콜백 처리**: 백엔드가 `${frontend}/auth/callback?code={uuid}` 로 redirect 한다.
+  클라이언트는 `code` 추출 후 즉시 `/exchange` 호출. (페이지 reload, 분석 스크립트
+  실행 전에 처리할 것 — Referer 누출 위험은 적지만 좋은 습관.)
+- **교환**: `POST /api/v1/auth/exchange` body `{ "code": "..." }`
+  → `{ accessToken, refreshToken, tokenType: "Bearer", expiresIn }`.
+- **이후 API**: 모든 인증 호출에 `Authorization: Bearer {accessToken}`.
+- **에러 redirect**: `${frontend}/auth/error?code={ErrorCode}` — §14 에러 코드 표 참조.
+- **CORS**: 프론트 origin 백엔드 화이트리스트 등록 필요. `credentials` 불필요.
+- **토큰 저장 정책 권고**:
+  - `accessToken`: **메모리 우선**. 새로고침 대비 fallback 으로 `sessionStorage` 까지 허용.
+    `localStorage` **금지** (XSS 노출면 확대).
+  - `refreshToken`: 동일 정책. 단계 2 에서 HttpOnly cookie 분리 검토 가능성 — 캡슐화하여
+    저장 매체 교체 비용 최소화.
+
+## 17. 마일스톤 (PR 분할)
+
+CLAUDE.md 의 단위 PR 원칙에 따라 6개로 분할 제안. 각 PR 완료 시 `code-reviewer`
+호출 (`security-reviewer` 가 별도 정의되어 있다면 PR3·PR5·PR6 에 추가 호출).
+
+| PR | 범위 | 의존 |
+|---|---|---|
+| PR1 | Domain 변경: `AuthProvider`, `User` 필드, `UserReader.findByProvider`, DB 스키마. | — |
+| PR2 | Application 포트/파사드 + 단위 테스트 (provider client, code store mock). | PR1 |
+| PR3 | Infrastructure: `KakaoOAuthProviderClient`, `NaverOAuthProviderClient` + WireMock 통합 테스트. | PR2 |
+| PR4 | Infrastructure: `InMemoryAuthCodeStore` + 동시성 테스트, `JwtAuthTokenIssuer`. | PR2 |
+| PR5 | Interface: 컨트롤러 2종 + `OAuthStateCookieManager` + `@WebMvcTest`. | PR3, PR4 |
+| PR6 | `SecurityConfig` 갱신 + `GlobalExceptionHandler` + e2e 통합 테스트. | PR5 |
+
+## 18. 결정 필요 사항 (구현 착수 전)
+
+| ID | 질문 | 권장 |
+|---|---|---|
+| D1 | OAuth 가입자의 `User.password` 처리 — 더미 값 vs nullable 변경 | nullable 변경 (`UserPassword?` 또는 컬럼 nullable). 기존 LOCAL 사용자에게는 영향 없음. |
+| D2 | `User` 테이블 마이그레이션 — Flyway vs `ddl-auto=update` | Flyway 도입 권장 (운영 안전성). 미도입 시 본 PR 에서 도입은 별도 ADR. |
+| D3 | Refresh token rotation 정책 — 사용자별 1개 vs 디바이스별 다중 | 단계 1 사용자별 1개 (기존 컨벤션 확인 후 결정). |
+| D4 | `JwtUtil.createToken` 의 `Bearer ` prefix 포함 동작 | 신규 코드는 prefix 제거 후 응답 body 로 분리. 기존 호출처 영향 검토 필요. |
+
+## 19. Open Questions
+
+- Q1: 프로젝트가 Flyway/Liquibase 를 도입했는지 확인 필요. (구현 시 `build.gradle.kts`
+  와 `src/main/resources/db/` 점검)
+- Q2: `RefreshToken` 도메인의 사용자별 다중성 정책 (현재 코드의 entity 와 repository
+  contract 점검 필요).
+- Q3: 단계 2 에서 refresh-only HttpOnly cookie 하이브리드 도입 시 CORS/도메인 정책
+  재설계 범위.
+- Q4: 모바일 앱 합류 시 callback URL 화이트리스트 / Universal Link / App Link 별도 PRD
+  필요.
+
+---
+
+**참고**:
+
+- ADR-0001 `docs/adr/0001-oauth-token-delivery-pattern.md` — (a)/(b)/(c) 결정 근거.
+- 기존 인증 코드: `system/security/JwtUtil.kt`, `JwtAuthorizationFilter.kt`,
+  `domain/user/User.kt`, `application/user/UserFacade.kt`, `interfaces/user/UserApiController.kt`.

--- a/src/main/kotlin/com/learner/language/application/auth/AuthCodeStore.kt
+++ b/src/main/kotlin/com/learner/language/application/auth/AuthCodeStore.kt
@@ -1,0 +1,8 @@
+package com.learner.language.application.auth
+
+import com.learner.language.domain.auth.AuthTokenSnapshot
+
+interface AuthCodeStore {
+    fun issue(snapshot: AuthTokenSnapshot): String
+    fun consume(code: String): AuthTokenSnapshot?
+}

--- a/src/main/kotlin/com/learner/language/application/auth/AuthExchangeFacade.kt
+++ b/src/main/kotlin/com/learner/language/application/auth/AuthExchangeFacade.kt
@@ -1,0 +1,19 @@
+package com.learner.language.application.auth
+
+import com.learner.language.domain.auth.OAuthAuthenticationException
+import com.learner.language.system.exception.ErrorCode
+import org.springframework.stereotype.Service
+
+@Service
+class AuthExchangeFacade(
+    private val authCodeStore: AuthCodeStore,
+) {
+    fun exchange(command: AuthExchangeCommand): AuthTokenResult {
+        val snapshot = authCodeStore.consume(command.code)
+            ?: throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_CODE_INVALID,
+                "유효하지 않거나 만료된 authorization code 입니다.",
+            )
+        return AuthTokenResult.from(snapshot)
+    }
+}

--- a/src/main/kotlin/com/learner/language/application/auth/AuthLogoutFacade.kt
+++ b/src/main/kotlin/com/learner/language/application/auth/AuthLogoutFacade.kt
@@ -1,0 +1,14 @@
+package com.learner.language.application.auth
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AuthLogoutFacade(
+    private val authTokenIssuer: AuthTokenIssuer,
+) {
+    @Transactional
+    fun logout(userId: Long) {
+        authTokenIssuer.revokeRefreshToken(userId)
+    }
+}

--- a/src/main/kotlin/com/learner/language/application/auth/AuthRefreshFacade.kt
+++ b/src/main/kotlin/com/learner/language/application/auth/AuthRefreshFacade.kt
@@ -1,0 +1,33 @@
+package com.learner.language.application.auth
+
+import com.learner.language.domain.user.UserReader
+import com.learner.language.infrastructure.user.UserRefreshTokenRepository
+import com.learner.language.system.exception.ErrorCode
+import com.learner.language.system.exception.LanguageException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AuthRefreshFacade(
+    private val userRefreshTokenRepository: UserRefreshTokenRepository,
+    private val userReader: UserReader,
+    private val authTokenIssuer: AuthTokenIssuer,
+) {
+
+    @Transactional
+    fun refresh(refreshToken: String): AuthTokenResult {
+        if (refreshToken.isBlank()) {
+            throw RefreshTokenInvalidException("refresh token이 비어있습니다.")
+        }
+        val stored = userRefreshTokenRepository.findByRefreshTokenRefreshToken(refreshToken)
+            .orElseThrow { RefreshTokenInvalidException("유효하지 않은 refresh token 입니다.") }
+        val user = userReader.getUserById(stored.userId)
+        return authTokenIssuer.issue(user)
+    }
+}
+
+class RefreshTokenInvalidException(message: String) : LanguageException(
+    ErrorCode.REFRESH_TOKEN_INVALID,
+    message,
+    publicCode = ErrorCode.REFRESH_TOKEN_INVALID.name,
+)

--- a/src/main/kotlin/com/learner/language/application/auth/AuthTokenIssuer.kt
+++ b/src/main/kotlin/com/learner/language/application/auth/AuthTokenIssuer.kt
@@ -1,0 +1,8 @@
+package com.learner.language.application.auth
+
+import com.learner.language.domain.user.User
+
+interface AuthTokenIssuer {
+    fun issue(user: User): AuthTokenResult
+    fun revokeRefreshToken(userId: Long)
+}

--- a/src/main/kotlin/com/learner/language/application/auth/AuthTokenResult.kt
+++ b/src/main/kotlin/com/learner/language/application/auth/AuthTokenResult.kt
@@ -1,0 +1,26 @@
+package com.learner.language.application.auth
+
+import com.learner.language.domain.auth.AuthTokenSnapshot
+
+data class AuthTokenResult(
+    val accessToken: String,
+    val refreshToken: String,
+    val tokenType: String,
+    val expiresInSeconds: Long,
+) {
+    fun toSnapshot(): AuthTokenSnapshot = AuthTokenSnapshot(
+        accessToken = accessToken,
+        refreshToken = refreshToken,
+        tokenType = tokenType,
+        expiresInSeconds = expiresInSeconds,
+    )
+
+    companion object {
+        fun from(snapshot: AuthTokenSnapshot): AuthTokenResult = AuthTokenResult(
+            accessToken = snapshot.accessToken,
+            refreshToken = snapshot.refreshToken,
+            tokenType = snapshot.tokenType,
+            expiresInSeconds = snapshot.expiresInSeconds,
+        )
+    }
+}

--- a/src/main/kotlin/com/learner/language/application/auth/OAuthCommand.kt
+++ b/src/main/kotlin/com/learner/language/application/auth/OAuthCommand.kt
@@ -1,0 +1,12 @@
+package com.learner.language.application.auth
+
+import com.learner.language.domain.user.AuthProvider
+
+data class OAuthLoginCommand(
+    val provider: AuthProvider,
+    val authorizationCode: String,
+)
+
+data class AuthExchangeCommand(
+    val code: String,
+)

--- a/src/main/kotlin/com/learner/language/application/auth/OAuthFacade.kt
+++ b/src/main/kotlin/com/learner/language/application/auth/OAuthFacade.kt
@@ -1,0 +1,62 @@
+package com.learner.language.application.auth
+
+import com.learner.language.domain.auth.OAuthAuthenticationException
+import com.learner.language.domain.user.AuthProvider
+import com.learner.language.domain.user.User
+import com.learner.language.domain.user.UserReader
+import com.learner.language.domain.user.UserService
+import com.learner.language.domain.user.UserWriter
+import com.learner.language.system.exception.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OAuthFacade(
+    providerClients: List<OAuthProviderClient>,
+    private val userReader: UserReader,
+    private val userWriter: UserWriter,
+    private val userService: UserService,
+    private val authTokenIssuer: AuthTokenIssuer,
+    private val authCodeStore: AuthCodeStore,
+) {
+    private val providerClientsByProvider: Map<AuthProvider, OAuthProviderClient> =
+        providerClients.associateBy { it.supports() }
+
+    @Transactional
+    fun login(command: OAuthLoginCommand): String {
+        val client = providerClientsByProvider[command.provider]
+            ?: throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_PROVIDER_ERROR,
+                "지원하지 않는 OAuth provider 입니다: ${command.provider}",
+            )
+
+        val userInfo = client.fetchUserInfo(command.authorizationCode)
+        val user = resolveUser(userInfo)
+        val tokenResult = authTokenIssuer.issue(user)
+
+        return authCodeStore.issue(tokenResult.toSnapshot())
+    }
+
+    private fun resolveUser(userInfo: OAuthUserInfo): User {
+        val existing = userReader.findByProvider(userInfo.provider, userInfo.externalId)
+        if (existing != null) {
+            existing.updateUsername(userInfo.displayName)
+            return userWriter.update(existing)
+        }
+
+        val byEmail = userReader.findByEmail(userInfo.email)
+        if (byEmail != null) {
+            throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_EMAIL_CONFLICT,
+                "이미 존재하는 이메일입니다: ${userInfo.email}",
+            )
+        }
+
+        return userService.createOAuthUser(
+            email = userInfo.email,
+            username = userInfo.displayName,
+            provider = userInfo.provider,
+            providerExternalId = userInfo.externalId,
+        )
+    }
+}

--- a/src/main/kotlin/com/learner/language/application/auth/OAuthProviderClient.kt
+++ b/src/main/kotlin/com/learner/language/application/auth/OAuthProviderClient.kt
@@ -1,0 +1,8 @@
+package com.learner.language.application.auth
+
+import com.learner.language.domain.user.AuthProvider
+
+interface OAuthProviderClient {
+    fun supports(): AuthProvider
+    fun fetchUserInfo(authorizationCode: String): OAuthUserInfo
+}

--- a/src/main/kotlin/com/learner/language/application/auth/OAuthUserInfo.kt
+++ b/src/main/kotlin/com/learner/language/application/auth/OAuthUserInfo.kt
@@ -1,0 +1,10 @@
+package com.learner.language.application.auth
+
+import com.learner.language.domain.user.AuthProvider
+
+interface OAuthUserInfo {
+    val provider: AuthProvider
+    val externalId: String
+    val email: String
+    val displayName: String
+}

--- a/src/main/kotlin/com/learner/language/application/comment/CommentCommand.kt
+++ b/src/main/kotlin/com/learner/language/application/comment/CommentCommand.kt
@@ -1,0 +1,8 @@
+package com.learner.language.application.comment
+
+data class CreateCommentCommand(
+    val diaryId: Long,
+    val authorUserId: Long,
+    val text: String,
+    val parentCommentId: Long?,
+)

--- a/src/main/kotlin/com/learner/language/application/comment/CommentLikeFacade.kt
+++ b/src/main/kotlin/com/learner/language/application/comment/CommentLikeFacade.kt
@@ -1,0 +1,51 @@
+package com.learner.language.application.comment
+
+import com.learner.language.domain.comment.CommentLike
+import com.learner.language.domain.comment.DiaryCommentReader
+import com.learner.language.domain.comment.DiaryCommentWriter
+import com.learner.language.infrastructure.comment.CommentLikeRepository
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CommentLikeFacade(
+    private val commentReader: DiaryCommentReader,
+    private val commentWriter: DiaryCommentWriter,
+    private val commentLikeRepository: CommentLikeRepository,
+) {
+
+    data class Result(
+        val commentId: Long,
+        val likeCount: Int,
+        val userLiked: Boolean,
+    )
+
+    @Transactional
+    fun setLiked(commentId: Long, userId: Long, liked: Boolean): Result {
+        val comment = commentReader.getById(commentId)
+        val currentlyLiked = commentLikeRepository.existsByCommentIdAndUserId(commentId, userId)
+
+        when {
+            liked && !currentlyLiked -> {
+                try {
+                    commentLikeRepository.save(CommentLike(commentId = commentId, userId = userId))
+                    commentWriter.incrementLikeCount(commentId)
+                } catch (_: DataIntegrityViolationException) {
+                    // 멱등 처리
+                }
+            }
+            !liked && currentlyLiked -> {
+                val removed = commentLikeRepository.deleteByCommentIdAndUserId(commentId, userId)
+                if (removed > 0) commentWriter.decrementLikeCount(commentId)
+            }
+        }
+
+        val updated = commentReader.getById(comment.id)
+        return Result(
+            commentId = updated.id,
+            likeCount = updated.likeCount,
+            userLiked = liked,
+        )
+    }
+}

--- a/src/main/kotlin/com/learner/language/application/comment/CommentView.kt
+++ b/src/main/kotlin/com/learner/language/application/comment/CommentView.kt
@@ -1,0 +1,15 @@
+package com.learner.language.application.comment
+
+import com.learner.language.application.diary.DiaryAuthorView
+import java.time.Instant
+
+data class DiaryCommentView(
+    val commentId: Long,
+    val diaryId: Long,
+    val author: DiaryAuthorView,
+    val text: String,
+    val createdAt: Instant,
+    val parentCommentId: Long?,
+    val likeCount: Int,
+    val userLiked: Boolean,
+)

--- a/src/main/kotlin/com/learner/language/application/comment/DiaryCommentFacade.kt
+++ b/src/main/kotlin/com/learner/language/application/comment/DiaryCommentFacade.kt
@@ -1,0 +1,118 @@
+package com.learner.language.application.comment
+
+import com.learner.language.application.diary.DiaryAuthorView
+import com.learner.language.common.pagination.CursorCodec
+import com.learner.language.common.pagination.CursorPage
+import com.learner.language.common.pagination.PageInfo
+import com.learner.language.domain.comment.DiaryComment
+import com.learner.language.domain.comment.DiaryCommentReader
+import com.learner.language.domain.comment.DiaryCommentWriter
+import com.learner.language.domain.comment.exception.CommentForbiddenException
+import com.learner.language.domain.comment.exception.CommentNotFoundException
+import com.learner.language.domain.comment.exception.CommentTooLongException
+import com.learner.language.domain.diary.DiaryReader
+import com.learner.language.domain.diary.DiaryWriter
+import com.learner.language.domain.user.UserReader
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.ZoneOffset
+
+@Service
+class DiaryCommentFacade(
+    private val diaryReader: DiaryReader,
+    private val diaryWriter: DiaryWriter,
+    private val commentReader: DiaryCommentReader,
+    private val commentWriter: DiaryCommentWriter,
+    private val userReader: UserReader,
+) {
+
+    @Transactional
+    fun create(command: CreateCommentCommand): DiaryCommentView {
+        val diary = diaryReader.getById(command.diaryId)
+        validateText(command.text)
+
+        if (command.parentCommentId != null) {
+            val exists = commentReader.existsInDiary(command.parentCommentId, diary.id)
+            if (!exists) {
+                throw CommentNotFoundException("Parent comment not found in diary: ${command.parentCommentId}")
+            }
+        }
+
+        val entity = DiaryComment(
+            diaryId = diary.id,
+            authorUserId = command.authorUserId,
+            text = command.text.trim(),
+            parentCommentId = command.parentCommentId,
+        )
+        val saved = commentWriter.save(entity)
+        diaryWriter.incrementCommentCount(diary.id)
+
+        val author = userReader.getUserById(command.authorUserId)
+        return DiaryCommentView(
+            commentId = saved.id,
+            diaryId = saved.diaryId,
+            author = DiaryAuthorView(author.id, author.username, null),
+            text = saved.text,
+            createdAt = saved.createdAt.toInstant(ZoneOffset.UTC),
+            parentCommentId = saved.parentCommentId,
+            likeCount = saved.likeCount,
+            userLiked = false,
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun list(diaryId: Long, cursorStr: String?, size: Int, viewerUserId: Long): CursorPage<DiaryCommentView> {
+        diaryReader.getById(diaryId)
+        val capped = size.coerceIn(1, MAX_PAGE_SIZE)
+        val cursor = CursorCodec.decode(cursorStr)
+        val comments = commentReader.findByDiary(diaryId, cursor, capped + 1)
+        val hasNext = comments.size > capped
+        val page = if (hasNext) comments.take(capped) else comments
+        val likedIds = commentReader.findLikedCommentIds(page.map { it.id }, viewerUserId)
+        val authors = page.map { it.authorUserId }.distinct()
+            .associateWith { userReader.getUserById(it) }
+
+        val items = page.map { comment ->
+            val author = authors.getValue(comment.authorUserId)
+            DiaryCommentView(
+                commentId = comment.id,
+                diaryId = comment.diaryId,
+                author = DiaryAuthorView(author.id, author.username, null),
+                text = comment.text,
+                createdAt = comment.createdAt.toInstant(ZoneOffset.UTC),
+                parentCommentId = comment.parentCommentId,
+                likeCount = comment.likeCount,
+                userLiked = comment.id in likedIds,
+            )
+        }
+        val nextCursor = if (hasNext) {
+            CursorCodec.encode(page.last().createdAt.toInstant(ZoneOffset.UTC), page.last().id)
+        } else null
+        return CursorPage(items, PageInfo(nextCursor, hasNext))
+    }
+
+    @Transactional
+    fun delete(commentId: Long, userId: Long) {
+        val comment = commentReader.getById(commentId)
+        if (!comment.isAuthoredBy(userId)) {
+            throw CommentForbiddenException("본인 댓글만 삭제 가능합니다.")
+        }
+        val diaryId = comment.diaryId
+        commentWriter.delete(comment)
+        diaryWriter.decrementCommentCount(diaryId)
+    }
+
+    private fun validateText(text: String) {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) {
+            throw CommentTooLongException("댓글 내용이 비어있습니다.")
+        }
+        if (trimmed.length > DiaryComment.MAX_TEXT_LENGTH) {
+            throw CommentTooLongException("댓글은 최대 ${DiaryComment.MAX_TEXT_LENGTH}자입니다.")
+        }
+    }
+
+    companion object {
+        private const val MAX_PAGE_SIZE = 100
+    }
+}

--- a/src/main/kotlin/com/learner/language/application/diary/DiaryCommand.kt
+++ b/src/main/kotlin/com/learner/language/application/diary/DiaryCommand.kt
@@ -1,0 +1,28 @@
+package com.learner.language.application.diary
+
+data class DiaryCreateCommand(
+    val authorUserId: Long,
+    val lines: List<String>,
+    val tags: List<String>,
+    val isPublic: Boolean,
+)
+
+data class DiaryFeedQuery(
+    val cursor: String?,
+    val size: Int,
+    val sort: DiaryFeedSort,
+    val tag: String?,
+)
+
+enum class DiaryFeedSort {
+    RECENT,
+    TRENDING;
+
+    companion object {
+        fun from(value: String?): DiaryFeedSort = when (value?.lowercase()) {
+            "trending" -> TRENDING
+            null, "recent" -> RECENT
+            else -> RECENT
+        }
+    }
+}

--- a/src/main/kotlin/com/learner/language/application/diary/DiaryFacade.kt
+++ b/src/main/kotlin/com/learner/language/application/diary/DiaryFacade.kt
@@ -1,0 +1,181 @@
+package com.learner.language.application.diary
+
+import com.learner.language.common.pagination.CursorCodec
+import com.learner.language.common.pagination.CursorPage
+import com.learner.language.common.pagination.PageInfo
+import com.learner.language.domain.diary.AccentToneResolver
+import com.learner.language.domain.diary.Diary
+import com.learner.language.domain.diary.DiaryLikeReader
+import com.learner.language.domain.diary.DiaryReader
+import com.learner.language.domain.diary.DiaryWriter
+import com.learner.language.domain.diary.exception.DiaryForbiddenException
+import com.learner.language.domain.diary.exception.InvalidLineCountException
+import com.learner.language.domain.diary.exception.InvalidLineLengthException
+import com.learner.language.domain.user.User
+import com.learner.language.domain.user.UserReader
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.ZoneOffset
+
+@Service
+class DiaryFacade(
+    private val diaryReader: DiaryReader,
+    private val diaryWriter: DiaryWriter,
+    private val diaryLikeReader: DiaryLikeReader,
+    private val userReader: UserReader,
+) {
+
+    @Transactional
+    fun create(command: DiaryCreateCommand): DiaryView {
+        validateLines(command.lines)
+        validateTags(command.tags)
+
+        val trimmed = command.lines.map { it.trim() }
+        val diary = Diary(
+            userId = command.authorUserId,
+            line1 = trimmed[0],
+            line2 = trimmed[1],
+            line3 = trimmed[2],
+            isPublic = command.isPublic,
+        )
+        val saved = diaryWriter.save(diary)
+
+        val normalizedTags = command.tags.map { it.trim() }.filter { it.isNotBlank() }.distinct()
+        diaryWriter.saveTags(saved.id, normalizedTags)
+
+        val author = userReader.getUserById(command.authorUserId)
+        return toView(saved, normalizedTags, author, userLiked = false)
+    }
+
+    @Transactional(readOnly = true)
+    fun getDetail(diaryId: Long, viewerUserId: Long): DiaryView {
+        val diary = diaryReader.getById(diaryId)
+        val tags = diaryReader.findTagsByDiaryId(diary.id)
+        val author = userReader.getUserById(diary.userId)
+        val userLiked = diaryLikeReader.isLikedBy(diary.id, viewerUserId)
+        return toView(diary, tags, author, userLiked = userLiked)
+    }
+
+    @Transactional(readOnly = true)
+    fun getFeed(query: DiaryFeedQuery, viewerUserId: Long): CursorPage<DiaryView> {
+        val size = query.size.coerceIn(1, MAX_PAGE_SIZE)
+        val cursor = CursorCodec.decode(query.cursor)
+        val diaries = when (query.sort) {
+            DiaryFeedSort.RECENT -> diaryReader.findPublicFeed(cursor, size + 1, query.tag)
+            DiaryFeedSort.TRENDING -> diaryReader.findPublicFeedTrending(cursor, size + 1)
+        }
+        return buildPage(diaries, size, query.sort, viewerUserId)
+    }
+
+    @Transactional(readOnly = true)
+    fun getMyFeed(userId: Long, cursorStr: String?, size: Int): CursorPage<DiaryView> {
+        val capped = size.coerceIn(1, MAX_PAGE_SIZE)
+        val cursor = CursorCodec.decode(cursorStr)
+        val diaries = diaryReader.findUserFeed(userId, cursor, capped + 1)
+        return buildPage(diaries, capped, DiaryFeedSort.RECENT, userId)
+    }
+
+    @Transactional
+    fun delete(diaryId: Long, authorUserId: Long) {
+        val diary = diaryReader.getById(diaryId)
+        if (!diary.isOwnedBy(authorUserId)) {
+            throw DiaryForbiddenException("본인 일기만 삭제 가능합니다.")
+        }
+        diaryWriter.deleteTagsByDiaryId(diary.id)
+        diaryWriter.delete(diary)
+    }
+
+    private fun buildPage(
+        diaries: List<Diary>,
+        size: Int,
+        sort: DiaryFeedSort,
+        viewerUserId: Long,
+    ): CursorPage<DiaryView> {
+        val hasNext = diaries.size > size
+        val page = if (hasNext) diaries.take(size) else diaries
+        val pageIds = page.map { it.id }
+        val tagsByDiary = diaryReader.findTagsByDiaryIds(pageIds)
+        val likedDiaryIds = diaryLikeReader.findLikedDiaryIds(pageIds, viewerUserId)
+        val authors = userReader.let { reader ->
+            page.map { it.userId }.distinct().associateWith { reader.getUserById(it) }
+        }
+        val items = page.map { diary ->
+            toView(
+                diary = diary,
+                tags = tagsByDiary[diary.id].orEmpty(),
+                author = authors.getValue(diary.userId),
+                userLiked = diary.id in likedDiaryIds,
+            )
+        }
+        val nextCursor = if (hasNext) encodeCursor(page.last(), sort) else null
+        return CursorPage(items, PageInfo(nextCursor, hasNext))
+    }
+
+    private fun encodeCursor(last: Diary, sort: DiaryFeedSort): String {
+        return when (sort) {
+            DiaryFeedSort.RECENT ->
+                CursorCodec.encode(last.createdAt.toInstant(ZoneOffset.UTC), last.id)
+            DiaryFeedSort.TRENDING ->
+                // trending: likeCount를 cursor의 createdAt 자리에 담아 유지 (millis로 치환)
+                CursorCodec.encode(
+                    java.time.Instant.ofEpochMilli(last.likeCount.toLong()),
+                    last.id,
+                )
+        }
+    }
+
+    private fun toView(diary: Diary, tags: List<String>, author: User, userLiked: Boolean): DiaryView {
+        return DiaryView(
+            diaryId = diary.id,
+            author = DiaryAuthorView(
+                userId = author.id,
+                username = author.username,
+                avatarUrl = null,
+            ),
+            lines = diary.lines(),
+            createdAt = diary.createdAt.toInstant(ZoneOffset.UTC),
+            tags = tags,
+            likeCount = diary.likeCount,
+            commentCount = diary.commentCount,
+            voiceParticipantCount = 0,
+            userLiked = userLiked,
+            isPublic = diary.isPublic,
+            accentTone = AccentToneResolver.of(diary.id),
+        )
+    }
+
+    private fun validateLines(lines: List<String>) {
+        if (lines.size != Diary.LINE_COUNT) {
+            throw InvalidLineCountException("3줄 일기는 반드시 ${Diary.LINE_COUNT}개 라인이어야 합니다.")
+        }
+        lines.forEachIndexed { idx, line ->
+            val trimmed = line.trim()
+            if (trimmed.isEmpty()) {
+                throw InvalidLineLengthException("${idx + 1}번째 라인이 비어있습니다.")
+            }
+            if (trimmed.length > Diary.LINE_MAX_LENGTH) {
+                throw InvalidLineLengthException(
+                    "${idx + 1}번째 라인이 최대 길이(${Diary.LINE_MAX_LENGTH})를 초과했습니다.",
+                )
+            }
+        }
+    }
+
+    private fun validateTags(tags: List<String>) {
+        if (tags.size > Diary.TAG_MAX_COUNT) {
+            throw InvalidLineLengthException("태그는 최대 ${Diary.TAG_MAX_COUNT}개까지 허용됩니다.")
+        }
+        tags.forEach { tag ->
+            val trimmed = tag.trim()
+            if (trimmed.isEmpty() || trimmed.length > Diary.TAG_MAX_LENGTH) {
+                throw InvalidLineLengthException(
+                    "태그는 1~${Diary.TAG_MAX_LENGTH}자여야 합니다.",
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val MAX_PAGE_SIZE = 50
+    }
+}

--- a/src/main/kotlin/com/learner/language/application/diary/DiaryLikeFacade.kt
+++ b/src/main/kotlin/com/learner/language/application/diary/DiaryLikeFacade.kt
@@ -1,0 +1,51 @@
+package com.learner.language.application.diary
+
+import com.learner.language.domain.diary.DiaryLike
+import com.learner.language.domain.diary.DiaryReader
+import com.learner.language.domain.diary.DiaryWriter
+import com.learner.language.infrastructure.diary.DiaryLikeRepository
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class DiaryLikeFacade(
+    private val diaryReader: DiaryReader,
+    private val diaryWriter: DiaryWriter,
+    private val diaryLikeRepository: DiaryLikeRepository,
+) {
+
+    data class Result(
+        val diaryId: Long,
+        val likeCount: Int,
+        val userLiked: Boolean,
+    )
+
+    @Transactional
+    fun setLiked(diaryId: Long, userId: Long, liked: Boolean): Result {
+        val diary = diaryReader.getById(diaryId)
+        val currentlyLiked = diaryLikeRepository.existsByDiaryIdAndUserId(diaryId, userId)
+
+        when {
+            liked && !currentlyLiked -> {
+                try {
+                    diaryLikeRepository.save(DiaryLike(diaryId = diaryId, userId = userId))
+                    diaryWriter.incrementLikeCount(diaryId)
+                } catch (_: DataIntegrityViolationException) {
+                    // 동시에 이미 좋아요가 들어간 경우: 멱등하므로 무시
+                }
+            }
+            !liked && currentlyLiked -> {
+                val removed = diaryLikeRepository.deleteByDiaryIdAndUserId(diaryId, userId)
+                if (removed > 0) diaryWriter.decrementLikeCount(diaryId)
+            }
+        }
+
+        val updated = diaryReader.getById(diary.id)
+        return Result(
+            diaryId = updated.id,
+            likeCount = updated.likeCount,
+            userLiked = liked,
+        )
+    }
+}

--- a/src/main/kotlin/com/learner/language/application/diary/DiaryView.kt
+++ b/src/main/kotlin/com/learner/language/application/diary/DiaryView.kt
@@ -1,0 +1,23 @@
+package com.learner.language.application.diary
+
+import java.time.Instant
+
+data class DiaryView(
+    val diaryId: Long,
+    val author: DiaryAuthorView,
+    val lines: List<String>,
+    val createdAt: Instant,
+    val tags: List<String>,
+    val likeCount: Int,
+    val commentCount: Int,
+    val voiceParticipantCount: Int,
+    val userLiked: Boolean,
+    val isPublic: Boolean,
+    val accentTone: String,
+)
+
+data class DiaryAuthorView(
+    val userId: Long,
+    val username: String,
+    val avatarUrl: String?,
+)

--- a/src/main/kotlin/com/learner/language/application/user/UserFacade.kt
+++ b/src/main/kotlin/com/learner/language/application/user/UserFacade.kt
@@ -2,9 +2,18 @@ package com.learner.language.application.user
 
 import com.learner.language.common.RandomNumber
 import com.learner.language.domain.email.MailService
-import com.learner.language.domain.user.*
+import com.learner.language.domain.user.PublicUserProfileInfo
+import com.learner.language.domain.user.User
+import com.learner.language.domain.user.UserCommand
+import com.learner.language.domain.user.UserInfo
+import com.learner.language.domain.user.UserReader
+import com.learner.language.domain.user.UserService
+import com.learner.language.domain.user.UserWriter
+import com.learner.language.infrastructure.diary.DiaryRepository
+import com.learner.language.infrastructure.profile.UserProfileRepository
 import com.learner.language.interfaces.user.UserDto
 import org.springframework.stereotype.Service
+import java.time.ZoneOffset
 
 @Service
 class UserFacade(
@@ -12,7 +21,9 @@ class UserFacade(
     private val userWriter: UserWriter,
     private val userService: UserService,
     private val mailService: MailService,
-    private val randomNumber: RandomNumber
+    private val randomNumber: RandomNumber,
+    private val userProfileRepository: UserProfileRepository,
+    private val diaryRepository: DiaryRepository,
 ) {
 
     fun sendValidationNumberToEmail(email: String) {
@@ -25,17 +36,41 @@ class UserFacade(
         userService.validateNumber(request)
     }
 
-
-
     fun registerUser(command: UserCommand): UserInfo {
-        val userInfo = userService.saveUser(command)
-
-        return userInfo
+        return userService.saveUser(command)
     }
 
     fun retrieveUserInfo(userId: Long): UserInfo {
-        val userInfo = userService.getUser(userId)
-
-        return userInfo
+        val user = userReader.getUserById(userId)
+        val avatarUrl = userProfileRepository.findByUserId(user.id)
+            .map { it.profileImageUrl }
+            .orElse(null)
+        return UserInfo.of(user, avatarUrl = avatarUrl)
     }
+
+    fun retrievePublicProfile(viewerUserId: Long, targetUserId: Long): PublicUserProfileInfo {
+        val user = userReader.getUserById(targetUserId)
+        val profile = userProfileRepository.findByUserId(user.id).orElse(null)
+        val diaryCount = diaryRepository.countByUserIdAndIsPublic(user.id, true)
+        return toPublicInfo(user, profile?.profileImageUrl, profile?.bio, diaryCount)
+    }
+
+    private fun toPublicInfo(
+        user: User,
+        avatarUrl: String?,
+        bio: String?,
+        diaryCount: Long,
+    ): PublicUserProfileInfo = PublicUserProfileInfo(
+        id = user.id,
+        userId = user.id,
+        username = user.username,
+        avatarUrl = avatarUrl,
+        provider = user.provider.name.lowercase(),
+        createdAt = user.createdAt.toInstant(ZoneOffset.UTC),
+        diaryCount = diaryCount,
+        followerCount = 0,
+        followingCount = 0,
+        isFollowing = false,
+        bio = bio,
+    )
 }

--- a/src/main/kotlin/com/learner/language/application/validation/DiaryValidationFacade.kt
+++ b/src/main/kotlin/com/learner/language/application/validation/DiaryValidationFacade.kt
@@ -1,0 +1,79 @@
+package com.learner.language.application.validation
+
+import com.learner.language.domain.diary.Diary
+import com.learner.language.domain.diary.exception.InvalidLineCountException
+import com.learner.language.domain.diary.exception.InvalidLineLengthException
+import com.learner.language.system.exception.ErrorCode
+import com.learner.language.system.exception.LanguageException
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class DiaryValidationFacade(
+    private val validator: DiaryValidator,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun validate(lines: List<String>): DiaryValidationResult {
+        validateLineCount(lines)
+        validateLineLength(lines)
+
+        val validationId = "val-${UUID.randomUUID().toString().replace("-", "").take(10)}"
+        val results = runWithErrorHandling { validator.validate(lines) }
+        return DiaryValidationResult(validationId, results)
+    }
+
+    fun validateLine(lineIndex: Int, text: String): LineValidation {
+        if (lineIndex < 0 || lineIndex >= Diary.LINE_COUNT) {
+            throw InvalidLineCountException("lineIndex 는 0..${Diary.LINE_COUNT - 1} 사이여야 합니다.")
+        }
+        validateLineLength(listOf(text))
+        return runWithErrorHandling { validator.validateLine(lineIndex, text) }
+    }
+
+    private fun <T> runWithErrorHandling(block: () -> T): T {
+        return try {
+            block()
+        } catch (e: ValidationTimeoutException) {
+            throw e
+        } catch (e: ValidationFailedException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn("Diary validation failed: {}", e.message, e)
+            throw ValidationFailedException("AI 검증 중 오류가 발생했습니다.")
+        }
+    }
+
+    private fun validateLineCount(lines: List<String>) {
+        if (lines.size != Diary.LINE_COUNT) {
+            throw InvalidLineCountException("라인은 ${Diary.LINE_COUNT}개여야 합니다.")
+        }
+    }
+
+    private fun validateLineLength(lines: List<String>) {
+        lines.forEachIndexed { idx, line ->
+            val trimmed = line.trim()
+            if (trimmed.isEmpty()) {
+                throw InvalidLineLengthException("${idx + 1}번째 라인이 비어있습니다.")
+            }
+            if (trimmed.length > Diary.LINE_MAX_LENGTH) {
+                throw InvalidLineLengthException(
+                    "${idx + 1}번째 라인이 ${Diary.LINE_MAX_LENGTH}자를 초과했습니다.",
+                )
+            }
+        }
+    }
+}
+
+class ValidationFailedException(message: String) : LanguageException(
+    ErrorCode.VALIDATION_FAILED,
+    message,
+    publicCode = ErrorCode.VALIDATION_FAILED.name,
+)
+
+class ValidationTimeoutException(message: String) : LanguageException(
+    ErrorCode.VALIDATION_TIMEOUT,
+    message,
+    publicCode = ErrorCode.VALIDATION_TIMEOUT.name,
+)

--- a/src/main/kotlin/com/learner/language/application/validation/DiaryValidationResult.kt
+++ b/src/main/kotlin/com/learner/language/application/validation/DiaryValidationResult.kt
@@ -1,0 +1,6 @@
+package com.learner.language.application.validation
+
+data class DiaryValidationResult(
+    val validationId: String,
+    val lines: List<LineValidation>,
+)

--- a/src/main/kotlin/com/learner/language/application/validation/DiaryValidator.kt
+++ b/src/main/kotlin/com/learner/language/application/validation/DiaryValidator.kt
@@ -1,0 +1,29 @@
+package com.learner.language.application.validation
+
+interface DiaryValidator {
+    fun validate(lines: List<String>): List<LineValidation>
+    fun validateLine(lineIndex: Int, text: String): LineValidation
+}
+
+data class LineValidation(
+    val lineIndex: Int,
+    val originalText: String,
+    val status: LineStatus,
+    val message: String,
+    val suggestion: String?,
+)
+
+enum class LineStatus {
+    OK, SUGGESTION, ERROR;
+
+    fun apiValue(): String = name.lowercase()
+
+    companion object {
+        fun fromApi(value: String?): LineStatus = when (value?.lowercase()) {
+            "ok" -> OK
+            "suggestion" -> SUGGESTION
+            "error" -> ERROR
+            else -> ERROR
+        }
+    }
+}

--- a/src/main/kotlin/com/learner/language/common/pagination/CursorCodec.kt
+++ b/src/main/kotlin/com/learner/language/common/pagination/CursorCodec.kt
@@ -1,0 +1,24 @@
+package com.learner.language.common.pagination
+
+import java.time.Instant
+import java.util.Base64
+
+object CursorCodec {
+
+    data class Cursor(val createdAt: Instant, val id: Long)
+
+    fun encode(createdAt: Instant, id: Long): String {
+        val raw = "${createdAt.toEpochMilli()}:$id"
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.toByteArray())
+    }
+
+    fun decode(cursor: String?): Cursor? {
+        if (cursor.isNullOrBlank()) return null
+        return runCatching {
+            val decoded = String(Base64.getUrlDecoder().decode(cursor))
+            val parts = decoded.split(":")
+            require(parts.size == 2)
+            Cursor(Instant.ofEpochMilli(parts[0].toLong()), parts[1].toLong())
+        }.getOrNull()
+    }
+}

--- a/src/main/kotlin/com/learner/language/common/pagination/CursorPage.kt
+++ b/src/main/kotlin/com/learner/language/common/pagination/CursorPage.kt
@@ -1,0 +1,11 @@
+package com.learner.language.common.pagination
+
+data class CursorPage<T>(
+    val items: List<T>,
+    val paging: PageInfo,
+)
+
+data class PageInfo(
+    val nextCursor: String?,
+    val hasNext: Boolean,
+)

--- a/src/main/kotlin/com/learner/language/domain/auth/AuthCode.kt
+++ b/src/main/kotlin/com/learner/language/domain/auth/AuthCode.kt
@@ -1,0 +1,11 @@
+package com.learner.language.domain.auth
+
+import java.time.Instant
+
+data class AuthCode(
+    val value: String,
+    val snapshot: AuthTokenSnapshot,
+    val expiresAt: Instant,
+) {
+    fun isExpired(now: Instant): Boolean = now.isAfter(expiresAt)
+}

--- a/src/main/kotlin/com/learner/language/domain/auth/AuthTokenSnapshot.kt
+++ b/src/main/kotlin/com/learner/language/domain/auth/AuthTokenSnapshot.kt
@@ -1,0 +1,8 @@
+package com.learner.language.domain.auth
+
+data class AuthTokenSnapshot(
+    val accessToken: String,
+    val refreshToken: String,
+    val tokenType: String,
+    val expiresInSeconds: Long,
+)

--- a/src/main/kotlin/com/learner/language/domain/auth/OAuthAuthenticationException.kt
+++ b/src/main/kotlin/com/learner/language/domain/auth/OAuthAuthenticationException.kt
@@ -1,0 +1,9 @@
+package com.learner.language.domain.auth
+
+import com.learner.language.system.exception.ErrorCode
+import com.learner.language.system.exception.LanguageException
+
+class OAuthAuthenticationException(
+    val oauthErrorCode: ErrorCode,
+    message: String,
+) : LanguageException(oauthErrorCode, message)

--- a/src/main/kotlin/com/learner/language/domain/comment/CommentLike.kt
+++ b/src/main/kotlin/com/learner/language/domain/comment/CommentLike.kt
@@ -1,0 +1,16 @@
+package com.learner.language.domain.comment
+
+import com.learner.language.common.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "comment_like")
+class CommentLike(
+    @Column(name = "comment_id", nullable = false)
+    var commentId: Long,
+
+    @Column(name = "user_id", nullable = false)
+    var userId: Long,
+) : BaseEntity()

--- a/src/main/kotlin/com/learner/language/domain/comment/DiaryComment.kt
+++ b/src/main/kotlin/com/learner/language/domain/comment/DiaryComment.kt
@@ -1,0 +1,32 @@
+package com.learner.language.domain.comment
+
+import com.learner.language.common.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "diary_comment")
+class DiaryComment(
+    @Column(name = "diary_id", nullable = false)
+    var diaryId: Long,
+
+    @Column(name = "author_user_id", nullable = false)
+    var authorUserId: Long,
+
+    @Column(name = "text", nullable = false, length = MAX_TEXT_LENGTH)
+    var text: String,
+
+    @Column(name = "parent_comment_id")
+    var parentCommentId: Long? = null,
+
+    @Column(name = "like_count", nullable = false)
+    var likeCount: Int = 0,
+) : BaseEntity() {
+
+    fun isAuthoredBy(userId: Long): Boolean = this.authorUserId == userId
+
+    companion object {
+        const val MAX_TEXT_LENGTH = 500
+    }
+}

--- a/src/main/kotlin/com/learner/language/domain/comment/DiaryCommentReader.kt
+++ b/src/main/kotlin/com/learner/language/domain/comment/DiaryCommentReader.kt
@@ -1,0 +1,11 @@
+package com.learner.language.domain.comment
+
+import com.learner.language.common.pagination.CursorCodec
+
+interface DiaryCommentReader {
+    fun getById(commentId: Long): DiaryComment
+    fun findByDiary(diaryId: Long, cursor: CursorCodec.Cursor?, size: Int): List<DiaryComment>
+    fun existsInDiary(commentId: Long, diaryId: Long): Boolean
+    fun findLikedCommentIds(commentIds: Collection<Long>, userId: Long): Set<Long>
+    fun isLikedBy(commentId: Long, userId: Long): Boolean
+}

--- a/src/main/kotlin/com/learner/language/domain/comment/DiaryCommentWriter.kt
+++ b/src/main/kotlin/com/learner/language/domain/comment/DiaryCommentWriter.kt
@@ -1,0 +1,8 @@
+package com.learner.language.domain.comment
+
+interface DiaryCommentWriter {
+    fun save(comment: DiaryComment): DiaryComment
+    fun delete(comment: DiaryComment)
+    fun incrementLikeCount(commentId: Long)
+    fun decrementLikeCount(commentId: Long)
+}

--- a/src/main/kotlin/com/learner/language/domain/comment/exception/CommentForbiddenException.kt
+++ b/src/main/kotlin/com/learner/language/domain/comment/exception/CommentForbiddenException.kt
@@ -1,0 +1,9 @@
+package com.learner.language.domain.comment.exception
+
+import com.learner.language.system.exception.ErrorCode
+import com.learner.language.system.exception.ForbiddenException
+
+class CommentForbiddenException(message: String) : ForbiddenException(
+    ErrorCode.COMMENT_FORBIDDEN,
+    message,
+)

--- a/src/main/kotlin/com/learner/language/domain/comment/exception/CommentNotFoundException.kt
+++ b/src/main/kotlin/com/learner/language/domain/comment/exception/CommentNotFoundException.kt
@@ -1,0 +1,9 @@
+package com.learner.language.domain.comment.exception
+
+import com.learner.language.system.exception.ErrorCode
+import com.learner.language.system.exception.NotFoundException
+
+class CommentNotFoundException(message: String) : NotFoundException(
+    ErrorCode.COMMENT_NOT_FOUND,
+    message,
+)

--- a/src/main/kotlin/com/learner/language/domain/comment/exception/CommentTooLongException.kt
+++ b/src/main/kotlin/com/learner/language/domain/comment/exception/CommentTooLongException.kt
@@ -1,0 +1,9 @@
+package com.learner.language.domain.comment.exception
+
+import com.learner.language.system.exception.BadRequestException
+import com.learner.language.system.exception.ErrorCode
+
+class CommentTooLongException(message: String) : BadRequestException(
+    ErrorCode.COMMENT_TOO_LONG,
+    message,
+)

--- a/src/main/kotlin/com/learner/language/domain/diary/AccentToneResolver.kt
+++ b/src/main/kotlin/com/learner/language/domain/diary/AccentToneResolver.kt
@@ -1,0 +1,10 @@
+package com.learner.language.domain.diary
+
+object AccentToneResolver {
+    private val TONES = listOf("cream", "apricot", "mint", "lavender", "outline")
+
+    fun of(diaryId: Long): String {
+        val idx = ((diaryId % TONES.size) + TONES.size) % TONES.size
+        return TONES[idx.toInt()]
+    }
+}

--- a/src/main/kotlin/com/learner/language/domain/diary/Diary.kt
+++ b/src/main/kotlin/com/learner/language/domain/diary/Diary.kt
@@ -1,0 +1,43 @@
+package com.learner.language.domain.diary
+
+import com.learner.language.common.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "diary")
+class Diary(
+    @Column(name = "user_id", nullable = false)
+    var userId: Long,
+
+    @Column(name = "line_1", nullable = false, length = LINE_MAX_LENGTH)
+    var line1: String,
+
+    @Column(name = "line_2", nullable = false, length = LINE_MAX_LENGTH)
+    var line2: String,
+
+    @Column(name = "line_3", nullable = false, length = LINE_MAX_LENGTH)
+    var line3: String,
+
+    @Column(name = "is_public", nullable = false)
+    var isPublic: Boolean = true,
+
+    @Column(name = "like_count", nullable = false)
+    var likeCount: Int = 0,
+
+    @Column(name = "comment_count", nullable = false)
+    var commentCount: Int = 0,
+) : BaseEntity() {
+
+    fun lines(): List<String> = listOf(line1, line2, line3)
+
+    fun isOwnedBy(userId: Long): Boolean = this.userId == userId
+
+    companion object {
+        const val LINE_COUNT = 3
+        const val LINE_MAX_LENGTH = 200
+        const val TAG_MAX_COUNT = 5
+        const val TAG_MAX_LENGTH = 32
+    }
+}

--- a/src/main/kotlin/com/learner/language/domain/diary/DiaryLike.kt
+++ b/src/main/kotlin/com/learner/language/domain/diary/DiaryLike.kt
@@ -1,0 +1,16 @@
+package com.learner.language.domain.diary
+
+import com.learner.language.common.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "diary_like")
+class DiaryLike(
+    @Column(name = "diary_id", nullable = false)
+    var diaryId: Long,
+
+    @Column(name = "user_id", nullable = false)
+    var userId: Long,
+) : BaseEntity()

--- a/src/main/kotlin/com/learner/language/domain/diary/DiaryLikeReader.kt
+++ b/src/main/kotlin/com/learner/language/domain/diary/DiaryLikeReader.kt
@@ -1,0 +1,6 @@
+package com.learner.language.domain.diary
+
+interface DiaryLikeReader {
+    fun isLikedBy(diaryId: Long, userId: Long): Boolean
+    fun findLikedDiaryIds(diaryIds: Collection<Long>, userId: Long): Set<Long>
+}

--- a/src/main/kotlin/com/learner/language/domain/diary/DiaryReader.kt
+++ b/src/main/kotlin/com/learner/language/domain/diary/DiaryReader.kt
@@ -1,0 +1,13 @@
+package com.learner.language.domain.diary
+
+import com.learner.language.common.pagination.CursorCodec
+
+interface DiaryReader {
+    fun getById(diaryId: Long): Diary
+    fun findById(diaryId: Long): Diary?
+    fun findPublicFeed(cursor: CursorCodec.Cursor?, size: Int, tag: String?): List<Diary>
+    fun findPublicFeedTrending(cursor: CursorCodec.Cursor?, size: Int): List<Diary>
+    fun findUserFeed(userId: Long, cursor: CursorCodec.Cursor?, size: Int): List<Diary>
+    fun findTagsByDiaryId(diaryId: Long): List<String>
+    fun findTagsByDiaryIds(diaryIds: Collection<Long>): Map<Long, List<String>>
+}

--- a/src/main/kotlin/com/learner/language/domain/diary/DiaryTag.kt
+++ b/src/main/kotlin/com/learner/language/domain/diary/DiaryTag.kt
@@ -1,0 +1,16 @@
+package com.learner.language.domain.diary
+
+import com.learner.language.common.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "diary_tag")
+class DiaryTag(
+    @Column(name = "diary_id", nullable = false)
+    var diaryId: Long,
+
+    @Column(name = "tag", nullable = false, length = Diary.TAG_MAX_LENGTH)
+    var tag: String,
+) : BaseEntity()

--- a/src/main/kotlin/com/learner/language/domain/diary/DiaryWriter.kt
+++ b/src/main/kotlin/com/learner/language/domain/diary/DiaryWriter.kt
@@ -1,0 +1,12 @@
+package com.learner.language.domain.diary
+
+interface DiaryWriter {
+    fun save(diary: Diary): Diary
+    fun delete(diary: Diary)
+    fun saveTags(diaryId: Long, tags: List<String>): List<DiaryTag>
+    fun deleteTagsByDiaryId(diaryId: Long)
+    fun incrementLikeCount(diaryId: Long)
+    fun decrementLikeCount(diaryId: Long)
+    fun incrementCommentCount(diaryId: Long)
+    fun decrementCommentCount(diaryId: Long)
+}

--- a/src/main/kotlin/com/learner/language/domain/diary/exception/DiaryForbiddenException.kt
+++ b/src/main/kotlin/com/learner/language/domain/diary/exception/DiaryForbiddenException.kt
@@ -1,0 +1,9 @@
+package com.learner.language.domain.diary.exception
+
+import com.learner.language.system.exception.ErrorCode
+import com.learner.language.system.exception.ForbiddenException
+
+class DiaryForbiddenException(message: String) : ForbiddenException(
+    ErrorCode.DIARY_FORBIDDEN,
+    message,
+)

--- a/src/main/kotlin/com/learner/language/domain/diary/exception/DiaryNotFoundException.kt
+++ b/src/main/kotlin/com/learner/language/domain/diary/exception/DiaryNotFoundException.kt
@@ -1,0 +1,9 @@
+package com.learner.language.domain.diary.exception
+
+import com.learner.language.system.exception.ErrorCode
+import com.learner.language.system.exception.NotFoundException
+
+class DiaryNotFoundException(message: String) : NotFoundException(
+    ErrorCode.DIARY_NOT_FOUND,
+    message,
+)

--- a/src/main/kotlin/com/learner/language/domain/diary/exception/InvalidLineCountException.kt
+++ b/src/main/kotlin/com/learner/language/domain/diary/exception/InvalidLineCountException.kt
@@ -1,0 +1,9 @@
+package com.learner.language.domain.diary.exception
+
+import com.learner.language.system.exception.ErrorCode
+import com.learner.language.system.exception.UnprocessableEntityException
+
+class InvalidLineCountException(message: String) : UnprocessableEntityException(
+    ErrorCode.INVALID_LINE_COUNT,
+    message,
+)

--- a/src/main/kotlin/com/learner/language/domain/diary/exception/InvalidLineLengthException.kt
+++ b/src/main/kotlin/com/learner/language/domain/diary/exception/InvalidLineLengthException.kt
@@ -1,0 +1,9 @@
+package com.learner.language.domain.diary.exception
+
+import com.learner.language.system.exception.BadRequestException
+import com.learner.language.system.exception.ErrorCode
+
+class InvalidLineLengthException(message: String) : BadRequestException(
+    ErrorCode.INVALID_LINE_LENGTH,
+    message,
+)

--- a/src/main/kotlin/com/learner/language/domain/user/AuthProvider.kt
+++ b/src/main/kotlin/com/learner/language/domain/user/AuthProvider.kt
@@ -1,0 +1,8 @@
+package com.learner.language.domain.user
+
+enum class AuthProvider {
+    LOCAL,
+    KAKAO,
+    NAVER,
+    GOOGLE,
+}

--- a/src/main/kotlin/com/learner/language/domain/user/PublicUserProfileInfo.kt
+++ b/src/main/kotlin/com/learner/language/domain/user/PublicUserProfileInfo.kt
@@ -1,0 +1,17 @@
+package com.learner.language.domain.user
+
+import java.time.Instant
+
+data class PublicUserProfileInfo(
+    val id: Long,
+    val userId: Long,
+    val username: String,
+    val avatarUrl: String?,
+    val provider: String,
+    val createdAt: Instant,
+    val diaryCount: Long,
+    val followerCount: Long,
+    val followingCount: Long,
+    val isFollowing: Boolean,
+    val bio: String?,
+)

--- a/src/main/kotlin/com/learner/language/domain/user/User.kt
+++ b/src/main/kotlin/com/learner/language/domain/user/User.kt
@@ -14,12 +14,42 @@ class User(
     var username: String,
 
     @Embedded
-    var password: UserPassword,
+    var password: UserPassword? = null,
 
     @Enumerated(EnumType.STRING)
-    var role: Role
+    var role: Role,
 
-): BaseEntity()
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false, length = 20)
+    var provider: AuthProvider = AuthProvider.LOCAL,
+
+    @Column(name = "provider_external_id", length = 100)
+    var providerExternalId: String? = null,
+
+): BaseEntity() {
+
+    fun updateUsername(newUsername: String) {
+        if (newUsername.isNotBlank() && newUsername != this.username) {
+            this.username = newUsername
+        }
+    }
+
+    companion object {
+        fun ofOAuth(
+            email: String,
+            username: String,
+            provider: AuthProvider,
+            providerExternalId: String,
+        ): User = User(
+            email = UserEmail(email),
+            username = username,
+            password = null,
+            role = Role.USER,
+            provider = provider,
+            providerExternalId = providerExternalId,
+        )
+    }
+}
 
 enum class Role {
     USER, ADMIN

--- a/src/main/kotlin/com/learner/language/domain/user/UserInfo.kt
+++ b/src/main/kotlin/com/learner/language/domain/user/UserInfo.kt
@@ -1,13 +1,24 @@
 package com.learner.language.domain.user
 
+import java.time.Instant
+import java.time.ZoneOffset
+
 data class UserInfo(
     val id: Long,
     val username: String,
-    val email: String
+    val email: String,
+    val provider: String,
+    val avatarUrl: String?,
+    val createdAt: Instant,
 ) {
-    constructor(user: User) : this(
-        id = user.id,
-        username = user.username,
-        email = user.email.email
-    )
+    companion object {
+        fun of(user: User, avatarUrl: String? = null): UserInfo = UserInfo(
+            id = user.id,
+            username = user.username,
+            email = user.email.email,
+            provider = user.provider.name.lowercase(),
+            avatarUrl = avatarUrl,
+            createdAt = user.createdAt.toInstant(ZoneOffset.UTC),
+        )
+    }
 }

--- a/src/main/kotlin/com/learner/language/domain/user/UserReader.kt
+++ b/src/main/kotlin/com/learner/language/domain/user/UserReader.kt
@@ -3,5 +3,7 @@ package com.learner.language.domain.user
 interface UserReader {
     fun getUserById(userId: Long): User
     fun getUserByEmail(email: String): User
+    fun findByEmail(email: String): User?
+    fun findByProvider(provider: AuthProvider, externalId: String): User?
     fun existsByEmail(userEmail: UserEmail): Boolean
 }

--- a/src/main/kotlin/com/learner/language/domain/user/UserService.kt
+++ b/src/main/kotlin/com/learner/language/domain/user/UserService.kt
@@ -9,4 +9,10 @@ interface UserService {
     fun checkEmailDuplicate(email: String)
     fun validateNumber(request: UserDto.ValidateNumberRequest)
     fun getUser(userId: Long?): UserInfo
+    fun createOAuthUser(
+        email: String,
+        username: String,
+        provider: AuthProvider,
+        providerExternalId: String,
+    ): User
 }

--- a/src/main/kotlin/com/learner/language/domain/user/UserServiceImpl.kt
+++ b/src/main/kotlin/com/learner/language/domain/user/UserServiceImpl.kt
@@ -1,8 +1,10 @@
 package com.learner.language.domain.user
 
 import com.learner.language.domain.email.MailService
+import com.learner.language.domain.profile.UserProfile
 import com.learner.language.domain.user.auth.AuthAuthenticationException
 import com.learner.language.domain.user.exception.UserBadRequestException
+import com.learner.language.infrastructure.profile.UserProfileRepository
 import com.learner.language.interfaces.user.UserDto
 import com.learner.language.system.security.CustomPasswordEncoder
 import com.learner.language.utils.RedisUtil
@@ -14,20 +16,22 @@ class UserServiceImpl(
     private val userWriter: UserWriter,
     private val passwordEncoder: CustomPasswordEncoder,
     private val mailService: MailService,
-    private val redisUtil: RedisUtil
+    private val redisUtil: RedisUtil,
+    private val userProfileRepository: UserProfileRepository,
 ) : UserService {
     override fun saveUser(userCommand: UserCommand): UserInfo {
         val initUser = userCommand.toEntity(passwordEncoder)
         val user = userWriter.save(initUser)
+        ensureUserProfile(user)
 
-        return UserInfo(user)
+        return UserInfo.of(user)
     }
 
     override fun updateUser(userCommand: UserCommand): UserInfo {
         val updateUser = userCommand.toEntity(passwordEncoder)
         val user = userWriter.update(updateUser)
 
-        return UserInfo(user)
+        return UserInfo.of(user)
     }
 
     override fun checkEmailDuplicate(email: String) {
@@ -56,7 +60,33 @@ class UserServiceImpl(
         }
         val user = userReader.getUserById(userId)
 
-        return UserInfo(user)
+        return UserInfo.of(user)
+    }
+
+    override fun createOAuthUser(
+        email: String,
+        username: String,
+        provider: AuthProvider,
+        providerExternalId: String,
+    ): User {
+        val newUser = User.ofOAuth(
+            email = email,
+            username = username,
+            provider = provider,
+            providerExternalId = providerExternalId,
+        )
+        val saved = userWriter.save(newUser)
+        ensureUserProfile(saved)
+        return saved
+    }
+
+    private fun ensureUserProfile(user: User) {
+        if (userProfileRepository.findByUserId(user.id).isPresent) return
+        val profile = UserProfile(
+            user = user,
+            displayName = user.username.take(30),
+        )
+        userProfileRepository.save(profile)
     }
 
 }

--- a/src/main/kotlin/com/learner/language/infrastructure/auth/AbstractOAuthProviderClient.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/auth/AbstractOAuthProviderClient.kt
@@ -1,0 +1,118 @@
+package com.learner.language.infrastructure.auth
+
+import com.learner.language.application.auth.OAuthProviderClient
+import com.learner.language.application.auth.OAuthUserInfo
+import com.learner.language.domain.auth.OAuthAuthenticationException
+import com.learner.language.system.exception.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.MediaType
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.RestClientResponseException
+
+abstract class AbstractOAuthProviderClient(
+    private val provider: OAuthProperties.Provider,
+    private val restClient: RestClient,
+) : OAuthProviderClient {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun fetchUserInfo(authorizationCode: String): OAuthUserInfo {
+        val accessToken = exchangeCodeForToken(authorizationCode)
+        val rawUserInfo = fetchRawUserInfo(accessToken)
+        return mapToUserInfo(rawUserInfo)
+    }
+
+    protected abstract fun mapToUserInfo(rawUserInfo: Map<String, Any?>): OAuthUserInfo
+
+    private fun exchangeCodeForToken(code: String): String {
+        val body = LinkedMultiValueMap<String, String>().apply {
+            add("grant_type", "authorization_code")
+            add("client_id", provider.clientId)
+            add("client_secret", provider.clientSecret)
+            add("redirect_uri", provider.redirectUri)
+            add("code", code)
+        }
+
+        val response = try {
+            restClient.post()
+                .uri(provider.tokenUri)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .body(body)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError) { _, res ->
+                    val errorBody = res.body.bufferedReader().use { it.readText() }
+                    log.warn("OAuth token exchange failed status={} body={}", res.statusCode, errorBody)
+                    throw OAuthAuthenticationException(
+                        ErrorCode.OAUTH_PROVIDER_ERROR,
+                        "OAuth token exchange failed: ${res.statusCode}",
+                    )
+                }
+                .body(Map::class.java)
+        } catch (e: OAuthAuthenticationException) {
+            throw e
+        } catch (e: RestClientResponseException) {
+            log.warn("OAuth token exchange RestClient error status={} body={}", e.statusCode, e.responseBodyAsString)
+            throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_PROVIDER_ERROR,
+                "OAuth token exchange failed",
+            )
+        } catch (e: Exception) {
+            log.warn("OAuth token exchange transport error: {}", e.message)
+            throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_PROVIDER_ERROR,
+                "OAuth token exchange transport failure",
+            )
+        }
+
+        val accessToken = response?.get("access_token") as? String
+            ?: throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_PROVIDER_ERROR,
+                "OAuth token response missing access_token",
+            )
+        return accessToken
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun fetchRawUserInfo(accessToken: String): Map<String, Any?> {
+        val response = try {
+            restClient.get()
+                .uri(provider.userInfoUri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
+                .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError) { _, res ->
+                    val errorBody = res.body.bufferedReader().use { it.readText() }
+                    log.warn("OAuth userinfo failed status={} body={}", res.statusCode, errorBody)
+                    throw OAuthAuthenticationException(
+                        ErrorCode.OAUTH_PROVIDER_ERROR,
+                        "OAuth userinfo failed: ${res.statusCode}",
+                    )
+                }
+                .body(Map::class.java)
+        } catch (e: OAuthAuthenticationException) {
+            throw e
+        } catch (e: RestClientResponseException) {
+            log.warn("OAuth userinfo RestClient error status={} body={}", e.statusCode, e.responseBodyAsString)
+            throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_PROVIDER_ERROR,
+                "OAuth userinfo failed",
+            )
+        } catch (e: Exception) {
+            log.warn("OAuth userinfo transport error: {}", e.message)
+            throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_PROVIDER_ERROR,
+                "OAuth userinfo transport failure",
+            )
+        }
+
+        return (response as? Map<String, Any?>)
+            ?: throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_PROVIDER_ERROR,
+                "OAuth userinfo body is empty",
+            )
+    }
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/auth/AuthAppProperties.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/auth/AuthAppProperties.kt
@@ -1,0 +1,12 @@
+package com.learner.language.infrastructure.auth
+
+import jakarta.validation.constraints.NotBlank
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
+
+@Validated
+@ConfigurationProperties(prefix = "app")
+data class AuthAppProperties(
+    @field:NotBlank val frontendBaseUrl: String,
+    @field:NotBlank val backendBaseUrl: String,
+)

--- a/src/main/kotlin/com/learner/language/infrastructure/auth/AuthCodeProperties.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/auth/AuthCodeProperties.kt
@@ -1,0 +1,9 @@
+package com.learner.language.infrastructure.auth
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+@ConfigurationProperties(prefix = "app.auth.auth-code")
+data class AuthCodeProperties(
+    val ttl: Duration = Duration.ofSeconds(60),
+)

--- a/src/main/kotlin/com/learner/language/infrastructure/auth/GoogleOAuthProviderClient.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/auth/GoogleOAuthProviderClient.kt
@@ -1,0 +1,42 @@
+package com.learner.language.infrastructure.auth
+
+import com.learner.language.application.auth.OAuthUserInfo
+import com.learner.language.domain.auth.OAuthAuthenticationException
+import com.learner.language.domain.user.AuthProvider
+import com.learner.language.system.exception.ErrorCode
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+
+@Component
+class GoogleOAuthProviderClient(
+    properties: OAuthProperties,
+    @Qualifier("oauthRestClient") restClient: RestClient,
+) : AbstractOAuthProviderClient(properties.google, restClient) {
+
+    override fun supports(): AuthProvider = AuthProvider.GOOGLE
+
+    override fun mapToUserInfo(rawUserInfo: Map<String, Any?>): OAuthUserInfo {
+        val externalId = rawUserInfo["sub"] as? String
+            ?: throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_PROVIDER_ERROR,
+                "Google userinfo missing sub",
+            )
+
+        val email = rawUserInfo["email"] as? String
+            ?: throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_EMAIL_REQUIRED,
+                "Google 계정에서 email scope 동의가 필요합니다.",
+            )
+
+        val displayName = (rawUserInfo["name"] as? String)
+            ?: (rawUserInfo["given_name"] as? String)
+            ?: email.substringBefore('@')
+
+        return GoogleOAuthUserInfo(
+            externalId = externalId,
+            email = email,
+            displayName = displayName,
+        )
+    }
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/auth/GoogleOAuthUserInfo.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/auth/GoogleOAuthUserInfo.kt
@@ -1,0 +1,12 @@
+package com.learner.language.infrastructure.auth
+
+import com.learner.language.application.auth.OAuthUserInfo
+import com.learner.language.domain.user.AuthProvider
+
+data class GoogleOAuthUserInfo(
+    override val externalId: String,
+    override val email: String,
+    override val displayName: String,
+) : OAuthUserInfo {
+    override val provider: AuthProvider = AuthProvider.GOOGLE
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/auth/InMemoryAuthCodeStore.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/auth/InMemoryAuthCodeStore.kt
@@ -1,0 +1,42 @@
+package com.learner.language.infrastructure.auth
+
+import com.learner.language.application.auth.AuthCodeStore
+import com.learner.language.domain.auth.AuthTokenSnapshot
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+class InMemoryAuthCodeStore(
+    private val properties: AuthCodeProperties,
+    private val clock: Clock = Clock.systemUTC(),
+) : AuthCodeStore {
+
+    private data class Entry(val snapshot: AuthTokenSnapshot, val expiresAt: Instant)
+
+    private val store: ConcurrentHashMap<String, Entry> = ConcurrentHashMap()
+
+    override fun issue(snapshot: AuthTokenSnapshot): String {
+        val code = UUID.randomUUID().toString()
+        val entry = Entry(snapshot, Instant.now(clock).plus(properties.ttl))
+        store[code] = entry
+        return code
+    }
+
+    override fun consume(code: String): AuthTokenSnapshot? {
+        val entry = store.remove(code) ?: return null
+        if (Instant.now(clock).isAfter(entry.expiresAt)) {
+            return null
+        }
+        return entry.snapshot
+    }
+
+    @Scheduled(fixedDelayString = "PT30S")
+    fun cleanupExpired() {
+        val now = Instant.now(clock)
+        store.entries.removeIf { now.isAfter(it.value.expiresAt) }
+    }
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/auth/JwtAuthTokenIssuer.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/auth/JwtAuthTokenIssuer.kt
@@ -1,0 +1,57 @@
+package com.learner.language.infrastructure.auth
+
+import com.learner.language.application.auth.AuthTokenIssuer
+import com.learner.language.application.auth.AuthTokenResult
+import com.learner.language.domain.user.User
+import com.learner.language.domain.user.UserRefreshToken
+import com.learner.language.infrastructure.user.UserRefreshTokenRepository
+import com.learner.language.system.security.JwtUtil
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class JwtAuthTokenIssuer(
+    private val jwtUtil: JwtUtil,
+    private val userRefreshTokenRepository: UserRefreshTokenRepository,
+) : AuthTokenIssuer {
+
+    override fun issue(user: User): AuthTokenResult {
+        val rawToken = jwtUtil.createToken(user.id, user.email.email)
+        val accessToken = if (rawToken.startsWith(JwtUtil.BEARER_PREFIX)) {
+            rawToken.removePrefix(JwtUtil.BEARER_PREFIX)
+        } else {
+            rawToken
+        }
+
+        val refreshTokenEntity = upsertRefreshToken(user.id)
+
+        return AuthTokenResult(
+            accessToken = accessToken,
+            refreshToken = refreshTokenEntity.refreshToken.refreshToken,
+            tokenType = "Bearer",
+            expiresInSeconds = ACCESS_TOKEN_TTL.seconds,
+        )
+    }
+
+    override fun revokeRefreshToken(userId: Long) {
+        userRefreshTokenRepository.findByUserId(userId).ifPresent {
+            userRefreshTokenRepository.delete(it)
+        }
+    }
+
+    private fun upsertRefreshToken(userId: Long): UserRefreshToken {
+        val existing = userRefreshTokenRepository.findByUserId(userId)
+        return if (existing.isPresent) {
+            existing.get().apply {
+                updateRefreshToken()
+                userRefreshTokenRepository.save(this)
+            }
+        } else {
+            userRefreshTokenRepository.save(UserRefreshToken(userId))
+        }
+    }
+
+    companion object {
+        private val ACCESS_TOKEN_TTL: Duration = Duration.ofDays(5)
+    }
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/auth/KakaoOAuthProviderClient.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/auth/KakaoOAuthProviderClient.kt
@@ -1,0 +1,49 @@
+package com.learner.language.infrastructure.auth
+
+import com.learner.language.application.auth.OAuthUserInfo
+import com.learner.language.domain.auth.OAuthAuthenticationException
+import com.learner.language.domain.user.AuthProvider
+import com.learner.language.system.exception.ErrorCode
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+
+@Component
+class KakaoOAuthProviderClient(
+    properties: OAuthProperties,
+    @Qualifier("oauthRestClient") restClient: RestClient,
+) : AbstractOAuthProviderClient(properties.kakao, restClient) {
+
+    override fun supports(): AuthProvider = AuthProvider.KAKAO
+
+    @Suppress("UNCHECKED_CAST")
+    override fun mapToUserInfo(rawUserInfo: Map<String, Any?>): OAuthUserInfo {
+        val externalId = (rawUserInfo["id"] as? Number)?.toString()
+            ?: throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_PROVIDER_ERROR,
+                "Kakao userinfo missing id",
+            )
+
+        val account = rawUserInfo["kakao_account"] as? Map<String, Any?>
+            ?: throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_PROVIDER_ERROR,
+                "Kakao userinfo missing kakao_account",
+            )
+
+        val email = account["email"] as? String
+            ?: throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_EMAIL_REQUIRED,
+                "Kakao 계정에서 email 동의가 필요합니다.",
+            )
+
+        val profile = account["profile"] as? Map<String, Any?>
+        val displayName = (profile?.get("nickname") as? String)
+            ?: email.substringBefore('@')
+
+        return KakaoOAuthUserInfo(
+            externalId = externalId,
+            email = email,
+            displayName = displayName,
+        )
+    }
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/auth/KakaoOAuthUserInfo.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/auth/KakaoOAuthUserInfo.kt
@@ -1,0 +1,12 @@
+package com.learner.language.infrastructure.auth
+
+import com.learner.language.application.auth.OAuthUserInfo
+import com.learner.language.domain.user.AuthProvider
+
+data class KakaoOAuthUserInfo(
+    override val externalId: String,
+    override val email: String,
+    override val displayName: String,
+) : OAuthUserInfo {
+    override val provider: AuthProvider = AuthProvider.KAKAO
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/auth/NaverOAuthProviderClient.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/auth/NaverOAuthProviderClient.kt
@@ -1,0 +1,49 @@
+package com.learner.language.infrastructure.auth
+
+import com.learner.language.application.auth.OAuthUserInfo
+import com.learner.language.domain.auth.OAuthAuthenticationException
+import com.learner.language.domain.user.AuthProvider
+import com.learner.language.system.exception.ErrorCode
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+
+@Component
+class NaverOAuthProviderClient(
+    properties: OAuthProperties,
+    @Qualifier("oauthRestClient") restClient: RestClient,
+) : AbstractOAuthProviderClient(properties.naver, restClient) {
+
+    override fun supports(): AuthProvider = AuthProvider.NAVER
+
+    @Suppress("UNCHECKED_CAST")
+    override fun mapToUserInfo(rawUserInfo: Map<String, Any?>): OAuthUserInfo {
+        val response = rawUserInfo["response"] as? Map<String, Any?>
+            ?: throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_PROVIDER_ERROR,
+                "Naver userinfo missing response",
+            )
+
+        val externalId = response["id"] as? String
+            ?: throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_PROVIDER_ERROR,
+                "Naver userinfo missing id",
+            )
+
+        val email = response["email"] as? String
+            ?: throw OAuthAuthenticationException(
+                ErrorCode.OAUTH_EMAIL_REQUIRED,
+                "Naver 계정에서 email 동의가 필요합니다.",
+            )
+
+        val displayName = (response["name"] as? String)
+            ?: (response["nickname"] as? String)
+            ?: email.substringBefore('@')
+
+        return NaverOAuthUserInfo(
+            externalId = externalId,
+            email = email,
+            displayName = displayName,
+        )
+    }
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/auth/NaverOAuthUserInfo.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/auth/NaverOAuthUserInfo.kt
@@ -1,0 +1,12 @@
+package com.learner.language.infrastructure.auth
+
+import com.learner.language.application.auth.OAuthUserInfo
+import com.learner.language.domain.user.AuthProvider
+
+data class NaverOAuthUserInfo(
+    override val externalId: String,
+    override val email: String,
+    override val displayName: String,
+) : OAuthUserInfo {
+    override val provider: AuthProvider = AuthProvider.NAVER
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/auth/OAuthProperties.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/auth/OAuthProperties.kt
@@ -1,0 +1,24 @@
+package com.learner.language.infrastructure.auth
+
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
+
+@Validated
+@ConfigurationProperties(prefix = "app.auth.oauth")
+data class OAuthProperties(
+    @field:Valid val kakao: Provider,
+    @field:Valid val naver: Provider,
+    @field:Valid val google: Provider,
+) {
+    data class Provider(
+        @field:NotBlank val clientId: String,
+        @field:NotBlank val clientSecret: String,
+        @field:NotBlank val redirectUri: String,
+        @field:NotBlank val authorizeUri: String,
+        @field:NotBlank val tokenUri: String,
+        @field:NotBlank val userInfoUri: String,
+        @field:NotBlank val scope: String,
+    )
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/auth/OAuthRestClientConfig.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/auth/OAuthRestClientConfig.kt
@@ -1,0 +1,22 @@
+package com.learner.language.infrastructure.auth
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.web.client.RestClient
+import java.time.Duration
+
+@Configuration
+class OAuthRestClientConfig {
+
+    @Bean
+    fun oauthRestClient(): RestClient {
+        val factory = SimpleClientHttpRequestFactory().apply {
+            setConnectTimeout(Duration.ofSeconds(5))
+            setReadTimeout(Duration.ofSeconds(10))
+        }
+        return RestClient.builder()
+            .requestFactory(factory)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/comment/CommentLikeRepository.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/comment/CommentLikeRepository.kt
@@ -1,0 +1,26 @@
+package com.learner.language.infrastructure.comment
+
+import com.learner.language.domain.comment.CommentLike
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CommentLikeRepository : JpaRepository<CommentLike, Long> {
+    fun existsByCommentIdAndUserId(commentId: Long, userId: Long): Boolean
+
+    @Query("SELECT l.commentId FROM CommentLike l WHERE l.commentId IN :commentIds AND l.userId = :userId")
+    fun findLikedCommentIds(
+        @Param("commentIds") commentIds: Collection<Long>,
+        @Param("userId") userId: Long,
+    ): List<Long>
+
+    @Modifying
+    @Query("DELETE FROM CommentLike l WHERE l.commentId = :commentId AND l.userId = :userId")
+    fun deleteByCommentIdAndUserId(
+        @Param("commentId") commentId: Long,
+        @Param("userId") userId: Long,
+    ): Int
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/comment/DiaryCommentReaderImpl.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/comment/DiaryCommentReaderImpl.kt
@@ -1,0 +1,40 @@
+package com.learner.language.infrastructure.comment
+
+import com.learner.language.common.pagination.CursorCodec
+import com.learner.language.domain.comment.DiaryComment
+import com.learner.language.domain.comment.DiaryCommentReader
+import com.learner.language.domain.comment.exception.CommentNotFoundException
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@Component
+class DiaryCommentReaderImpl(
+    private val diaryCommentRepository: DiaryCommentRepository,
+    private val commentLikeRepository: CommentLikeRepository,
+) : DiaryCommentReader {
+
+    override fun getById(commentId: Long): DiaryComment {
+        return diaryCommentRepository.findById(commentId)
+            .orElseThrow { CommentNotFoundException("Comment not found: $commentId") }
+    }
+
+    override fun findByDiary(diaryId: Long, cursor: CursorCodec.Cursor?, size: Int): List<DiaryComment> {
+        val cursorCreatedAt = cursor?.let { LocalDateTime.ofInstant(it.createdAt, ZoneOffset.UTC) }
+        val cursorId = cursor?.id
+        val pageable = PageRequest.of(0, size)
+        return diaryCommentRepository.findByDiaryIdFromCursor(diaryId, cursorCreatedAt, cursorId, pageable)
+    }
+
+    override fun existsInDiary(commentId: Long, diaryId: Long): Boolean =
+        diaryCommentRepository.existsByIdAndDiaryId(commentId, diaryId)
+
+    override fun findLikedCommentIds(commentIds: Collection<Long>, userId: Long): Set<Long> {
+        if (commentIds.isEmpty()) return emptySet()
+        return commentLikeRepository.findLikedCommentIds(commentIds, userId).toSet()
+    }
+
+    override fun isLikedBy(commentId: Long, userId: Long): Boolean =
+        commentLikeRepository.existsByCommentIdAndUserId(commentId, userId)
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/comment/DiaryCommentRepository.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/comment/DiaryCommentRepository.kt
@@ -1,0 +1,41 @@
+package com.learner.language.infrastructure.comment
+
+import com.learner.language.domain.comment.DiaryComment
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+@Repository
+interface DiaryCommentRepository : JpaRepository<DiaryComment, Long> {
+
+    @Query(
+        """
+        SELECT c FROM DiaryComment c
+        WHERE c.diaryId = :diaryId
+          AND (:cursorCreatedAt IS NULL
+               OR c.createdAt > :cursorCreatedAt
+               OR (c.createdAt = :cursorCreatedAt AND c.id > :cursorId))
+        ORDER BY c.createdAt ASC, c.id ASC
+        """
+    )
+    fun findByDiaryIdFromCursor(
+        @Param("diaryId") diaryId: Long,
+        @Param("cursorCreatedAt") cursorCreatedAt: LocalDateTime?,
+        @Param("cursorId") cursorId: Long?,
+        pageable: Pageable,
+    ): List<DiaryComment>
+
+    fun existsByIdAndDiaryId(id: Long, diaryId: Long): Boolean
+
+    @Modifying
+    @Query("UPDATE DiaryComment c SET c.likeCount = c.likeCount + 1 WHERE c.id = :id")
+    fun incrementLikeCount(@Param("id") id: Long): Int
+
+    @Modifying
+    @Query("UPDATE DiaryComment c SET c.likeCount = c.likeCount - 1 WHERE c.id = :id AND c.likeCount > 0")
+    fun decrementLikeCount(@Param("id") id: Long): Int
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/comment/DiaryCommentWriterImpl.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/comment/DiaryCommentWriterImpl.kt
@@ -1,0 +1,25 @@
+package com.learner.language.infrastructure.comment
+
+import com.learner.language.domain.comment.DiaryComment
+import com.learner.language.domain.comment.DiaryCommentWriter
+import org.springframework.stereotype.Component
+
+@Component
+class DiaryCommentWriterImpl(
+    private val diaryCommentRepository: DiaryCommentRepository,
+) : DiaryCommentWriter {
+
+    override fun save(comment: DiaryComment): DiaryComment = diaryCommentRepository.save(comment)
+
+    override fun delete(comment: DiaryComment) {
+        diaryCommentRepository.delete(comment)
+    }
+
+    override fun incrementLikeCount(commentId: Long) {
+        diaryCommentRepository.incrementLikeCount(commentId)
+    }
+
+    override fun decrementLikeCount(commentId: Long) {
+        diaryCommentRepository.decrementLikeCount(commentId)
+    }
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/diary/DiaryLikeReaderImpl.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/diary/DiaryLikeReaderImpl.kt
@@ -1,0 +1,18 @@
+package com.learner.language.infrastructure.diary
+
+import com.learner.language.domain.diary.DiaryLikeReader
+import org.springframework.stereotype.Component
+
+@Component
+class DiaryLikeReaderImpl(
+    private val diaryLikeRepository: DiaryLikeRepository,
+) : DiaryLikeReader {
+
+    override fun isLikedBy(diaryId: Long, userId: Long): Boolean =
+        diaryLikeRepository.existsByDiaryIdAndUserId(diaryId, userId)
+
+    override fun findLikedDiaryIds(diaryIds: Collection<Long>, userId: Long): Set<Long> {
+        if (diaryIds.isEmpty()) return emptySet()
+        return diaryLikeRepository.findLikedDiaryIds(diaryIds, userId).toSet()
+    }
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/diary/DiaryLikeRepository.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/diary/DiaryLikeRepository.kt
@@ -1,0 +1,26 @@
+package com.learner.language.infrastructure.diary
+
+import com.learner.language.domain.diary.DiaryLike
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface DiaryLikeRepository : JpaRepository<DiaryLike, Long> {
+    fun existsByDiaryIdAndUserId(diaryId: Long, userId: Long): Boolean
+
+    @Query("SELECT l.diaryId FROM DiaryLike l WHERE l.diaryId IN :diaryIds AND l.userId = :userId")
+    fun findLikedDiaryIds(
+        @Param("diaryIds") diaryIds: Collection<Long>,
+        @Param("userId") userId: Long,
+    ): List<Long>
+
+    @Modifying
+    @Query("DELETE FROM DiaryLike l WHERE l.diaryId = :diaryId AND l.userId = :userId")
+    fun deleteByDiaryIdAndUserId(
+        @Param("diaryId") diaryId: Long,
+        @Param("userId") userId: Long,
+    ): Int
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/diary/DiaryReaderImpl.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/diary/DiaryReaderImpl.kt
@@ -1,0 +1,65 @@
+package com.learner.language.infrastructure.diary
+
+import com.learner.language.common.pagination.CursorCodec
+import com.learner.language.domain.diary.Diary
+import com.learner.language.domain.diary.DiaryReader
+import com.learner.language.domain.diary.exception.DiaryNotFoundException
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@Component
+class DiaryReaderImpl(
+    private val diaryRepository: DiaryRepository,
+    private val diaryTagRepository: DiaryTagRepository,
+) : DiaryReader {
+
+    override fun getById(diaryId: Long): Diary {
+        return diaryRepository.findById(diaryId)
+            .orElseThrow { DiaryNotFoundException("Diary not found: $diaryId") }
+    }
+
+    override fun findById(diaryId: Long): Diary? {
+        return diaryRepository.findById(diaryId).orElse(null)
+    }
+
+    override fun findPublicFeed(cursor: CursorCodec.Cursor?, size: Int, tag: String?): List<Diary> {
+        val cursorCreatedAt = cursor?.let { LocalDateTime.ofInstant(it.createdAt, ZoneOffset.UTC) }
+        val cursorId = cursor?.id
+        val pageable = PageRequest.of(0, size)
+        return if (tag.isNullOrBlank()) {
+            diaryRepository.findPublicFeedRecent(cursorCreatedAt, cursorId, pageable)
+        } else {
+            diaryRepository.findPublicFeedByTagRecent(tag, cursorCreatedAt, cursorId, pageable)
+        }
+    }
+
+    override fun findPublicFeedTrending(cursor: CursorCodec.Cursor?, size: Int): List<Diary> {
+        val pageable = PageRequest.of(0, size)
+        val cursorLikeCount = cursor?.let {
+            // trending cursor: id(ts) 자리를 likeCount로 재사용 — cursor.createdAt.epochMilli를 likeCount로 간주
+            it.createdAt.toEpochMilli().toInt()
+        }
+        val cursorId = cursor?.id
+        return diaryRepository.findPublicFeedTrending(cursorLikeCount, cursorId, pageable)
+    }
+
+    override fun findUserFeed(userId: Long, cursor: CursorCodec.Cursor?, size: Int): List<Diary> {
+        val cursorCreatedAt = cursor?.let { LocalDateTime.ofInstant(it.createdAt, ZoneOffset.UTC) }
+        val cursorId = cursor?.id
+        val pageable = PageRequest.of(0, size)
+        return diaryRepository.findUserFeedRecent(userId, cursorCreatedAt, cursorId, pageable)
+    }
+
+    override fun findTagsByDiaryId(diaryId: Long): List<String> {
+        return diaryTagRepository.findByDiaryId(diaryId).map { it.tag }
+    }
+
+    override fun findTagsByDiaryIds(diaryIds: Collection<Long>): Map<Long, List<String>> {
+        if (diaryIds.isEmpty()) return emptyMap()
+        return diaryTagRepository.findByDiaryIdIn(diaryIds)
+            .groupBy { it.diaryId }
+            .mapValues { (_, tags) -> tags.map { it.tag } }
+    }
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/diary/DiaryRepository.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/diary/DiaryRepository.kt
@@ -1,0 +1,99 @@
+package com.learner.language.infrastructure.diary
+
+import com.learner.language.domain.diary.Diary
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+@Repository
+interface DiaryRepository : JpaRepository<Diary, Long> {
+
+    @Query(
+        """
+        SELECT d FROM Diary d
+        WHERE d.isPublic = true
+          AND (:cursorCreatedAt IS NULL
+               OR d.createdAt < :cursorCreatedAt
+               OR (d.createdAt = :cursorCreatedAt AND d.id < :cursorId))
+        ORDER BY d.createdAt DESC, d.id DESC
+        """
+    )
+    fun findPublicFeedRecent(
+        @Param("cursorCreatedAt") cursorCreatedAt: LocalDateTime?,
+        @Param("cursorId") cursorId: Long?,
+        pageable: Pageable,
+    ): List<Diary>
+
+    @Query(
+        """
+        SELECT d FROM Diary d
+        WHERE d.isPublic = true
+          AND (:cursorLikeCount IS NULL
+               OR d.likeCount < :cursorLikeCount
+               OR (d.likeCount = :cursorLikeCount AND d.id < :cursorId))
+        ORDER BY d.likeCount DESC, d.id DESC
+        """
+    )
+    fun findPublicFeedTrending(
+        @Param("cursorLikeCount") cursorLikeCount: Int?,
+        @Param("cursorId") cursorId: Long?,
+        pageable: Pageable,
+    ): List<Diary>
+
+    @Query(
+        """
+        SELECT d FROM Diary d
+        WHERE d.isPublic = true
+          AND d.id IN (SELECT t.diaryId FROM DiaryTag t WHERE t.tag = :tag)
+          AND (:cursorCreatedAt IS NULL
+               OR d.createdAt < :cursorCreatedAt
+               OR (d.createdAt = :cursorCreatedAt AND d.id < :cursorId))
+        ORDER BY d.createdAt DESC, d.id DESC
+        """
+    )
+    fun findPublicFeedByTagRecent(
+        @Param("tag") tag: String,
+        @Param("cursorCreatedAt") cursorCreatedAt: LocalDateTime?,
+        @Param("cursorId") cursorId: Long?,
+        pageable: Pageable,
+    ): List<Diary>
+
+    @Query(
+        """
+        SELECT d FROM Diary d
+        WHERE d.userId = :userId
+          AND (:cursorCreatedAt IS NULL
+               OR d.createdAt < :cursorCreatedAt
+               OR (d.createdAt = :cursorCreatedAt AND d.id < :cursorId))
+        ORDER BY d.createdAt DESC, d.id DESC
+        """
+    )
+    fun findUserFeedRecent(
+        @Param("userId") userId: Long,
+        @Param("cursorCreatedAt") cursorCreatedAt: LocalDateTime?,
+        @Param("cursorId") cursorId: Long?,
+        pageable: Pageable,
+    ): List<Diary>
+
+    fun countByUserIdAndIsPublic(userId: Long, isPublic: Boolean): Long
+
+    @Modifying
+    @Query("UPDATE Diary d SET d.likeCount = d.likeCount + 1 WHERE d.id = :id")
+    fun incrementLikeCount(@Param("id") id: Long): Int
+
+    @Modifying
+    @Query("UPDATE Diary d SET d.likeCount = d.likeCount - 1 WHERE d.id = :id AND d.likeCount > 0")
+    fun decrementLikeCount(@Param("id") id: Long): Int
+
+    @Modifying
+    @Query("UPDATE Diary d SET d.commentCount = d.commentCount + 1 WHERE d.id = :id")
+    fun incrementCommentCount(@Param("id") id: Long): Int
+
+    @Modifying
+    @Query("UPDATE Diary d SET d.commentCount = d.commentCount - 1 WHERE d.id = :id AND d.commentCount > 0")
+    fun decrementCommentCount(@Param("id") id: Long): Int
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/diary/DiaryTagRepository.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/diary/DiaryTagRepository.kt
@@ -1,0 +1,18 @@
+package com.learner.language.infrastructure.diary
+
+import com.learner.language.domain.diary.DiaryTag
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface DiaryTagRepository : JpaRepository<DiaryTag, Long> {
+    fun findByDiaryId(diaryId: Long): List<DiaryTag>
+    fun findByDiaryIdIn(diaryIds: Collection<Long>): List<DiaryTag>
+
+    @Modifying
+    @Query("DELETE FROM DiaryTag t WHERE t.diaryId = :diaryId")
+    fun deleteByDiaryId(@Param("diaryId") diaryId: Long): Int
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/diary/DiaryWriterImpl.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/diary/DiaryWriterImpl.kt
@@ -1,0 +1,45 @@
+package com.learner.language.infrastructure.diary
+
+import com.learner.language.domain.diary.Diary
+import com.learner.language.domain.diary.DiaryTag
+import com.learner.language.domain.diary.DiaryWriter
+import org.springframework.stereotype.Component
+
+@Component
+class DiaryWriterImpl(
+    private val diaryRepository: DiaryRepository,
+    private val diaryTagRepository: DiaryTagRepository,
+) : DiaryWriter {
+
+    override fun save(diary: Diary): Diary = diaryRepository.save(diary)
+
+    override fun delete(diary: Diary) {
+        diaryRepository.delete(diary)
+    }
+
+    override fun saveTags(diaryId: Long, tags: List<String>): List<DiaryTag> {
+        if (tags.isEmpty()) return emptyList()
+        val entities = tags.map { DiaryTag(diaryId = diaryId, tag = it) }
+        return diaryTagRepository.saveAll(entities).toList()
+    }
+
+    override fun deleteTagsByDiaryId(diaryId: Long) {
+        diaryTagRepository.deleteByDiaryId(diaryId)
+    }
+
+    override fun incrementLikeCount(diaryId: Long) {
+        diaryRepository.incrementLikeCount(diaryId)
+    }
+
+    override fun decrementLikeCount(diaryId: Long) {
+        diaryRepository.decrementLikeCount(diaryId)
+    }
+
+    override fun incrementCommentCount(diaryId: Long) {
+        diaryRepository.incrementCommentCount(diaryId)
+    }
+
+    override fun decrementCommentCount(diaryId: Long) {
+        diaryRepository.decrementCommentCount(diaryId)
+    }
+}

--- a/src/main/kotlin/com/learner/language/infrastructure/user/UserReaderImpl.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/user/UserReaderImpl.kt
@@ -1,5 +1,6 @@
 package com.learner.language.infrastructure.user
 
+import com.learner.language.domain.user.AuthProvider
 import com.learner.language.domain.user.User
 import com.learner.language.domain.user.UserEmail
 import com.learner.language.domain.user.UserReader
@@ -23,6 +24,15 @@ class UserReaderImpl(
             .orElseThrow {
                 EntityNotFoundException()
             }
+    }
+
+    override fun findByEmail(email: String): User? {
+        val userEmail = UserEmail(email)
+        return userRepository.findByEmail(userEmail).orElse(null)
+    }
+
+    override fun findByProvider(provider: AuthProvider, externalId: String): User? {
+        return userRepository.findByProviderAndProviderExternalId(provider, externalId).orElse(null)
     }
 
     override fun existsByEmail(userEmail: UserEmail): Boolean {

--- a/src/main/kotlin/com/learner/language/infrastructure/user/UserRepository.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/user/UserRepository.kt
@@ -1,5 +1,6 @@
 package com.learner.language.infrastructure.user
 
+import com.learner.language.domain.user.AuthProvider
 import com.learner.language.domain.user.User
 import com.learner.language.domain.user.UserEmail
 import org.springframework.data.repository.CrudRepository
@@ -10,4 +11,5 @@ import java.util.*
 interface UserRepository : CrudRepository<User, Long> {
     fun findByEmail(userEmail: UserEmail): Optional<User>
     fun existsByEmail(userEmail: UserEmail): Boolean
+    fun findByProviderAndProviderExternalId(provider: AuthProvider, providerExternalId: String): Optional<User>
 }

--- a/src/main/kotlin/com/learner/language/infrastructure/validation/OpenAiDiaryValidator.kt
+++ b/src/main/kotlin/com/learner/language/infrastructure/validation/OpenAiDiaryValidator.kt
@@ -1,0 +1,142 @@
+package com.learner.language.infrastructure.validation
+
+import com.learner.language.application.validation.DiaryValidator
+import com.learner.language.application.validation.LineStatus
+import com.learner.language.application.validation.LineValidation
+import com.learner.language.application.validation.ValidationFailedException
+import com.learner.language.application.validation.ValidationTimeoutException
+import com.learner.language.domain.diary.Diary
+import org.slf4j.LoggerFactory
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.stereotype.Component
+import java.net.SocketTimeoutException
+import java.util.concurrent.TimeoutException
+
+@Component
+class OpenAiDiaryValidator(
+    private val chatClient: ChatClient,
+) : DiaryValidator {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    data class AiLine(
+        val lineIndex: Int = 0,
+        val status: String = "error",
+        val message: String = "",
+        val suggestion: String? = null,
+    )
+
+    data class AiValidationResponse(
+        val lines: List<AiLine> = emptyList(),
+    )
+
+    data class AiSingleLineResponse(
+        val lineIndex: Int = 0,
+        val status: String = "error",
+        val message: String = "",
+        val suggestion: String? = null,
+    )
+
+    override fun validate(lines: List<String>): List<LineValidation> {
+        require(lines.size == Diary.LINE_COUNT) { "lines must be 3" }
+        val prompt = buildBatchPrompt(lines)
+        val response = try {
+            chatClient.prompt()
+                .user(prompt)
+                .call()
+                .entity(AiValidationResponse::class.java)
+        } catch (e: Exception) {
+            handleAiException(e)
+        } ?: throw ValidationFailedException("AI 검증 응답이 비어있습니다.")
+
+        val resultByIndex = response.lines.associateBy { it.lineIndex }
+        return lines.mapIndexed { idx, original ->
+            val ai = resultByIndex[idx]
+            LineValidation(
+                lineIndex = idx,
+                originalText = original,
+                status = LineStatus.fromApi(ai?.status),
+                message = ai?.message ?: fallbackMessage(ai?.status),
+                suggestion = normalizeSuggestion(ai?.status, ai?.suggestion),
+            )
+        }
+    }
+
+    override fun validateLine(lineIndex: Int, text: String): LineValidation {
+        val prompt = buildSingleLinePrompt(lineIndex, text)
+        val response = try {
+            chatClient.prompt()
+                .user(prompt)
+                .call()
+                .entity(AiSingleLineResponse::class.java)
+        } catch (e: Exception) {
+            handleAiException(e)
+        } ?: throw ValidationFailedException("AI 검증 응답이 비어있습니다.")
+
+        return LineValidation(
+            lineIndex = lineIndex,
+            originalText = text,
+            status = LineStatus.fromApi(response.status),
+            message = response.message.ifBlank { fallbackMessage(response.status) },
+            suggestion = normalizeSuggestion(response.status, response.suggestion),
+        )
+    }
+
+    private fun handleAiException(e: Exception): Nothing {
+        log.warn("AI validation call failed: {}", e.message, e)
+        if (e is TimeoutException || e is SocketTimeoutException ||
+            (e.message?.contains("timeout", ignoreCase = true) == true)
+        ) {
+            throw ValidationTimeoutException("AI 응답이 시간 내에 도착하지 않았습니다.")
+        }
+        throw ValidationFailedException("AI 검증에 실패했습니다: ${e.message}")
+    }
+
+    private fun buildBatchPrompt(lines: List<String>): String = """
+        You are a Korean-language tutor helping a learner write natural three-line diary entries.
+        Evaluate each of the three Korean sentences below. Respond in JSON only.
+
+        Sentences:
+        [0] ${lines[0]}
+        [1] ${lines[1]}
+        [2] ${lines[2]}
+
+        For each line, decide the status:
+        - "ok": grammatically correct and sounds natural.
+        - "suggestion": grammatically fine but could be more natural or polished.
+        - "error": grammatically wrong and must be fixed before posting.
+
+        Rules:
+        - "message" should be a short tutor feedback (Korean or English or mix, under 200 characters).
+        - "suggestion" must be a complete improved Korean sentence when status is "suggestion" or "error". Use null when status is "ok".
+        - Return lines in order with lineIndex 0, 1, 2.
+    """.trimIndent()
+
+    private fun buildSingleLinePrompt(lineIndex: Int, text: String): String = """
+        You are a Korean-language tutor. Evaluate the following Korean sentence and respond in JSON only.
+
+        Sentence: $text
+
+        Decide status:
+        - "ok": natural and correct.
+        - "suggestion": grammatically fine but could be more natural.
+        - "error": grammatical mistake that must be fixed.
+
+        Rules:
+        - Return lineIndex = $lineIndex.
+        - "message" under 200 characters (Korean or English).
+        - "suggestion" is a complete improved sentence, or null when status is "ok".
+    """.trimIndent()
+
+    private fun fallbackMessage(status: String?): String = when (LineStatus.fromApi(status)) {
+        LineStatus.OK -> "Sounds natural!"
+        LineStatus.SUGGESTION -> "조금 더 자연스럽게 다듬어 볼 수 있어요."
+        LineStatus.ERROR -> "문법을 다시 확인해 주세요."
+    }
+
+    private fun normalizeSuggestion(status: String?, suggestion: String?): String? {
+        val s = LineStatus.fromApi(status)
+        if (s == LineStatus.OK) return null
+        return suggestion?.takeIf { it.isNotBlank() }
+    }
+}

--- a/src/main/kotlin/com/learner/language/interfaces/auth/AuthDto.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/auth/AuthDto.kt
@@ -1,0 +1,29 @@
+package com.learner.language.interfaces.auth
+
+import com.learner.language.application.auth.AuthExchangeCommand
+import com.learner.language.application.auth.AuthTokenResult
+import jakarta.validation.constraints.NotBlank
+
+object AuthDto {
+    data class ExchangeRequest(
+        @field:NotBlank val code: String,
+    ) {
+        fun toCommand(): AuthExchangeCommand = AuthExchangeCommand(code)
+    }
+
+    data class ExchangeResponse(
+        val accessToken: String,
+        val refreshToken: String,
+        val tokenType: String,
+        val expiresIn: Long,
+    ) {
+        companion object {
+            fun from(result: AuthTokenResult): ExchangeResponse = ExchangeResponse(
+                accessToken = result.accessToken,
+                refreshToken = result.refreshToken,
+                tokenType = result.tokenType,
+                expiresIn = result.expiresInSeconds,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/learner/language/interfaces/auth/AuthExchangeController.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/auth/AuthExchangeController.kt
@@ -1,0 +1,23 @@
+package com.learner.language.interfaces.auth
+
+import com.learner.language.application.auth.AuthExchangeFacade
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth")
+class AuthExchangeController(
+    private val authExchangeFacade: AuthExchangeFacade,
+) {
+    @PostMapping("/exchange")
+    fun exchange(
+        @Valid @RequestBody request: AuthDto.ExchangeRequest,
+    ): ResponseEntity<AuthDto.ExchangeResponse> {
+        val result = authExchangeFacade.exchange(request.toCommand())
+        return ResponseEntity.ok(AuthDto.ExchangeResponse.from(result))
+    }
+}

--- a/src/main/kotlin/com/learner/language/interfaces/auth/AuthLogoutController.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/auth/AuthLogoutController.kt
@@ -1,0 +1,20 @@
+package com.learner.language.interfaces.auth
+
+import com.learner.language.application.auth.AuthLogoutFacade
+import com.learner.language.system.login.LoginUser
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth")
+class AuthLogoutController(
+    private val authLogoutFacade: AuthLogoutFacade,
+) {
+    @PostMapping("/logout")
+    fun logout(@LoginUser userId: Long): ResponseEntity<Void> {
+        authLogoutFacade.logout(userId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/learner/language/interfaces/auth/AuthRefreshController.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/auth/AuthRefreshController.kt
@@ -1,0 +1,29 @@
+package com.learner.language.interfaces.auth
+
+import com.learner.language.application.auth.AuthRefreshFacade
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth")
+class AuthRefreshController(
+    private val authRefreshFacade: AuthRefreshFacade,
+) {
+
+    data class RefreshRequest(
+        @field:NotBlank val refreshToken: String,
+    )
+
+    @PostMapping("/refresh")
+    fun refresh(
+        @Valid @RequestBody request: RefreshRequest,
+    ): ResponseEntity<AuthDto.ExchangeResponse> {
+        val result = authRefreshFacade.refresh(request.refreshToken)
+        return ResponseEntity.ok(AuthDto.ExchangeResponse.from(result))
+    }
+}

--- a/src/main/kotlin/com/learner/language/interfaces/auth/OAuthBrowserController.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/auth/OAuthBrowserController.kt
@@ -1,0 +1,135 @@
+package com.learner.language.interfaces.auth
+
+import com.learner.language.application.auth.OAuthFacade
+import com.learner.language.application.auth.OAuthLoginCommand
+import com.learner.language.domain.auth.OAuthAuthenticationException
+import com.learner.language.domain.user.AuthProvider
+import com.learner.language.infrastructure.auth.AuthAppProperties
+import com.learner.language.infrastructure.auth.OAuthProperties
+import com.learner.language.system.exception.ErrorCode
+import com.learner.language.system.security.OAuthStateCookieManager
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/auth/oauth")
+class OAuthBrowserController(
+    private val oauthFacade: OAuthFacade,
+    private val oauthProperties: OAuthProperties,
+    private val appProperties: AuthAppProperties,
+    private val stateCookieManager: OAuthStateCookieManager,
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @GetMapping("/{provider}/start")
+    fun start(
+        @PathVariable("provider") providerName: String,
+        response: HttpServletResponse,
+    ): ResponseEntity<Void> {
+        val provider = parseProvider(providerName)
+        val providerConfig = providerConfig(provider)
+        val state = UUID.randomUUID().toString()
+
+        stateCookieManager.set(response, provider, state)
+
+        val authorizeUrl = UriComponentsBuilder.fromUriString(providerConfig.authorizeUri)
+            .queryParam("response_type", "code")
+            .queryParam("client_id", providerConfig.clientId)
+            .queryParam("redirect_uri", providerConfig.redirectUri)
+            .queryParam("scope", providerConfig.scope)
+            .queryParam("state", state)
+            .encode()
+            .build()
+            .toUriString()
+
+        return ResponseEntity.status(HttpStatus.FOUND)
+            .header(HttpHeaders.LOCATION, authorizeUrl)
+            .build()
+    }
+
+    @GetMapping("/{provider}/callback")
+    fun callback(
+        @PathVariable("provider") providerName: String,
+        @RequestParam(name = "code", required = false) code: String?,
+        @RequestParam(name = "state", required = false) state: String?,
+        @RequestParam(name = "error", required = false) error: String?,
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+    ): ResponseEntity<Void> {
+        val provider = parseProvider(providerName)
+        val storedState = stateCookieManager.get(request, provider)
+
+        try {
+            if (!error.isNullOrBlank() || code.isNullOrBlank()) {
+                log.warn("OAuth provider returned error provider={} error={}", provider, error)
+                return errorRedirect(ErrorCode.OAUTH_AUTHORIZATION_FAILED)
+            }
+
+            if (storedState.isNullOrBlank() || state.isNullOrBlank() || storedState != state) {
+                log.warn("OAuth state mismatch provider={} cookieState={} requestState={}", provider, storedState, state)
+                return errorRedirect(ErrorCode.OAUTH_STATE_INVALID)
+            }
+
+            val authCode = oauthFacade.login(OAuthLoginCommand(provider, code))
+            val location = "${appProperties.frontendBaseUrl}/auth/callback?code=" +
+                URLEncoder.encode(authCode, StandardCharsets.UTF_8)
+
+            return ResponseEntity.status(HttpStatus.FOUND)
+                .header(HttpHeaders.LOCATION, location)
+                .build()
+        } catch (e: OAuthAuthenticationException) {
+            return errorRedirect(e.oauthErrorCode)
+        } finally {
+            stateCookieManager.clear(response, provider)
+        }
+    }
+
+    private fun parseProvider(name: String): AuthProvider {
+        return runCatching { AuthProvider.valueOf(name.uppercase()) }
+            .getOrElse {
+                throw OAuthAuthenticationException(
+                    ErrorCode.OAUTH_AUTHORIZATION_FAILED,
+                    "지원하지 않는 OAuth provider 입니다: $name",
+                )
+            }.also {
+                if (it == AuthProvider.LOCAL) {
+                    throw OAuthAuthenticationException(
+                        ErrorCode.OAUTH_AUTHORIZATION_FAILED,
+                        "LOCAL provider 는 OAuth 흐름을 사용할 수 없습니다.",
+                    )
+                }
+            }
+    }
+
+    private fun providerConfig(provider: AuthProvider): OAuthProperties.Provider = when (provider) {
+        AuthProvider.KAKAO -> oauthProperties.kakao
+        AuthProvider.NAVER -> oauthProperties.naver
+        AuthProvider.GOOGLE -> oauthProperties.google
+        AuthProvider.LOCAL -> throw OAuthAuthenticationException(
+            ErrorCode.OAUTH_AUTHORIZATION_FAILED,
+            "LOCAL provider 는 OAuth 흐름을 사용할 수 없습니다.",
+        )
+    }
+
+    private fun errorRedirect(errorCode: ErrorCode): ResponseEntity<Void> {
+        val location = "${appProperties.frontendBaseUrl}/auth/error?code=" +
+            URLEncoder.encode(errorCode.name, StandardCharsets.UTF_8)
+        return ResponseEntity.status(HttpStatus.FOUND)
+            .header(HttpHeaders.LOCATION, location)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/learner/language/interfaces/comment/CommentController.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/comment/CommentController.kt
@@ -1,0 +1,40 @@
+package com.learner.language.interfaces.comment
+
+import com.learner.language.application.comment.CommentLikeFacade
+import com.learner.language.application.comment.DiaryCommentFacade
+import com.learner.language.system.login.LoginUser
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/comments")
+class CommentController(
+    private val commentFacade: DiaryCommentFacade,
+    private val commentLikeFacade: CommentLikeFacade,
+) {
+
+    @PostMapping("/{commentId}/like")
+    fun toggleLike(
+        @LoginUser userId: Long,
+        @PathVariable commentId: Long,
+        @Valid @RequestBody request: CommentDto.LikeToggleRequest,
+    ): ResponseEntity<CommentDto.LikeToggleResponse> {
+        val result = commentLikeFacade.setLiked(commentId, userId, request.liked)
+        return ResponseEntity.ok(CommentDto.LikeToggleResponse.from(result))
+    }
+
+    @DeleteMapping("/{commentId}")
+    fun delete(
+        @LoginUser userId: Long,
+        @PathVariable commentId: Long,
+    ): ResponseEntity<Void> {
+        commentFacade.delete(commentId, userId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/learner/language/interfaces/comment/CommentDto.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/comment/CommentDto.kt
@@ -1,0 +1,82 @@
+package com.learner.language.interfaces.comment
+
+import com.learner.language.application.comment.CommentLikeFacade
+import com.learner.language.application.comment.CreateCommentCommand
+import com.learner.language.application.comment.DiaryCommentView
+import com.learner.language.common.pagination.CursorPage
+import com.learner.language.common.pagination.PageInfo
+import com.learner.language.interfaces.diary.DiaryDto
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.Instant
+
+object CommentDto {
+
+    data class CreateRequest(
+        @field:NotBlank
+        val text: String,
+        val parentCommentId: Long? = null,
+    ) {
+        fun toCommand(diaryId: Long, authorUserId: Long) = CreateCommentCommand(
+            diaryId = diaryId,
+            authorUserId = authorUserId,
+            text = text,
+            parentCommentId = parentCommentId,
+        )
+    }
+
+    data class CommentResponse(
+        val commentId: Long,
+        val diaryId: Long,
+        val author: DiaryDto.AuthorResponse,
+        val text: String,
+        val createdAt: Instant,
+        val parentCommentId: Long?,
+        val likeCount: Int,
+        val userLiked: Boolean,
+    ) {
+        companion object {
+            fun from(view: DiaryCommentView) = CommentResponse(
+                commentId = view.commentId,
+                diaryId = view.diaryId,
+                author = DiaryDto.AuthorResponse.from(view.author),
+                text = view.text,
+                createdAt = view.createdAt,
+                parentCommentId = view.parentCommentId,
+                likeCount = view.likeCount,
+                userLiked = view.userLiked,
+            )
+        }
+    }
+
+    data class CommentListResponse(
+        val items: List<CommentResponse>,
+        val paging: PageInfo,
+    ) {
+        companion object {
+            fun from(page: CursorPage<DiaryCommentView>) = CommentListResponse(
+                items = page.items.map { CommentResponse.from(it) },
+                paging = page.paging,
+            )
+        }
+    }
+
+    data class LikeToggleRequest(
+        @field:NotNull
+        val liked: Boolean,
+    )
+
+    data class LikeToggleResponse(
+        val commentId: Long,
+        val likeCount: Int,
+        val userLiked: Boolean,
+    ) {
+        companion object {
+            fun from(result: CommentLikeFacade.Result) = LikeToggleResponse(
+                commentId = result.commentId,
+                likeCount = result.likeCount,
+                userLiked = result.userLiked,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/learner/language/interfaces/comment/DiaryCommentController.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/comment/DiaryCommentController.kt
@@ -1,0 +1,43 @@
+package com.learner.language.interfaces.comment
+
+import com.learner.language.application.comment.DiaryCommentFacade
+import com.learner.language.system.login.LoginUser
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/diaries/{diaryId}/comments")
+class DiaryCommentController(
+    private val commentFacade: DiaryCommentFacade,
+) {
+
+    @GetMapping
+    fun list(
+        @LoginUser userId: Long,
+        @PathVariable diaryId: Long,
+        @RequestParam(required = false) cursor: String?,
+        @RequestParam(required = false, defaultValue = "20") size: Int,
+    ): ResponseEntity<CommentDto.CommentListResponse> {
+        val page = commentFacade.list(diaryId, cursor, size, userId)
+        return ResponseEntity.ok(CommentDto.CommentListResponse.from(page))
+    }
+
+    @PostMapping
+    fun create(
+        @LoginUser userId: Long,
+        @PathVariable diaryId: Long,
+        @Valid @RequestBody request: CommentDto.CreateRequest,
+    ): ResponseEntity<CommentDto.CommentResponse> {
+        val view = commentFacade.create(request.toCommand(diaryId, userId))
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(CommentDto.CommentResponse.from(view))
+    }
+}

--- a/src/main/kotlin/com/learner/language/interfaces/diary/DiaryController.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/diary/DiaryController.kt
@@ -1,0 +1,80 @@
+package com.learner.language.interfaces.diary
+
+import com.learner.language.application.diary.DiaryFacade
+import com.learner.language.application.diary.DiaryFeedQuery
+import com.learner.language.application.diary.DiaryFeedSort
+import com.learner.language.system.login.LoginUser
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/diaries")
+class DiaryController(
+    private val diaryFacade: DiaryFacade,
+) {
+
+    @GetMapping("/feed")
+    fun getFeed(
+        @LoginUser userId: Long,
+        @RequestParam(required = false) cursor: String?,
+        @RequestParam(required = false, defaultValue = "10") size: Int,
+        @RequestParam(required = false, defaultValue = "recent") sort: String,
+        @RequestParam(required = false) category: String?,
+    ): ResponseEntity<DiaryDto.FeedResponse> {
+        val query = DiaryFeedQuery(
+            cursor = cursor,
+            size = size,
+            sort = DiaryFeedSort.from(sort),
+            tag = category,
+        )
+        val page = diaryFacade.getFeed(query, userId)
+        return ResponseEntity.ok(DiaryDto.FeedResponse.from(page))
+    }
+
+    @GetMapping("/me")
+    fun getMyFeed(
+        @LoginUser userId: Long,
+        @RequestParam(required = false) cursor: String?,
+        @RequestParam(required = false, defaultValue = "10") size: Int,
+    ): ResponseEntity<DiaryDto.FeedResponse> {
+        val page = diaryFacade.getMyFeed(userId, cursor, size)
+        return ResponseEntity.ok(DiaryDto.FeedResponse.from(page))
+    }
+
+    @GetMapping("/{diaryId}")
+    fun getDetail(
+        @LoginUser userId: Long,
+        @PathVariable diaryId: Long,
+    ): ResponseEntity<DiaryDto.DiaryResponse> {
+        val view = diaryFacade.getDetail(diaryId, userId)
+        return ResponseEntity.ok(DiaryDto.DiaryResponse.from(view))
+    }
+
+    @PostMapping
+    fun create(
+        @LoginUser userId: Long,
+        @Valid @RequestBody request: DiaryDto.CreateRequest,
+    ): ResponseEntity<DiaryDto.DiaryResponse> {
+        val view = diaryFacade.create(request.toCommand(userId))
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(DiaryDto.DiaryResponse.from(view))
+    }
+
+    @DeleteMapping("/{diaryId}")
+    fun delete(
+        @LoginUser userId: Long,
+        @PathVariable diaryId: Long,
+    ): ResponseEntity<Void> {
+        diaryFacade.delete(diaryId, userId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/learner/language/interfaces/diary/DiaryDto.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/diary/DiaryDto.kt
@@ -1,0 +1,84 @@
+package com.learner.language.interfaces.diary
+
+import com.learner.language.application.diary.DiaryAuthorView
+import com.learner.language.application.diary.DiaryCreateCommand
+import com.learner.language.application.diary.DiaryView
+import com.learner.language.common.pagination.CursorPage
+import com.learner.language.common.pagination.PageInfo
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import java.time.Instant
+
+object DiaryDto {
+
+    data class CreateRequest(
+        @field:NotNull
+        @field:Size(min = 3, max = 3, message = "lines는 정확히 3개여야 합니다.")
+        val lines: List<String> = emptyList(),
+        val tags: List<String> = emptyList(),
+        val isPublic: Boolean = true,
+    ) {
+        fun toCommand(authorUserId: Long): DiaryCreateCommand = DiaryCreateCommand(
+            authorUserId = authorUserId,
+            lines = lines,
+            tags = tags,
+            isPublic = isPublic,
+        )
+    }
+
+    data class AuthorResponse(
+        val userId: Long,
+        val username: String,
+        val avatarUrl: String?,
+    ) {
+        companion object {
+            fun from(view: DiaryAuthorView) = AuthorResponse(
+                userId = view.userId,
+                username = view.username,
+                avatarUrl = view.avatarUrl,
+            )
+        }
+    }
+
+    data class DiaryResponse(
+        val diaryId: Long,
+        val author: AuthorResponse,
+        val lines: List<String>,
+        val createdAt: Instant,
+        val tags: List<String>,
+        val likeCount: Int,
+        val commentCount: Int,
+        val voiceParticipantCount: Int,
+        val userLiked: Boolean,
+        val isPublic: Boolean,
+        val accentTone: String,
+    ) {
+        companion object {
+            fun from(view: DiaryView) = DiaryResponse(
+                diaryId = view.diaryId,
+                author = AuthorResponse.from(view.author),
+                lines = view.lines,
+                createdAt = view.createdAt,
+                tags = view.tags,
+                likeCount = view.likeCount,
+                commentCount = view.commentCount,
+                voiceParticipantCount = view.voiceParticipantCount,
+                userLiked = view.userLiked,
+                isPublic = view.isPublic,
+                accentTone = view.accentTone,
+            )
+        }
+    }
+
+    data class FeedResponse(
+        val items: List<DiaryResponse>,
+        val paging: PageInfo,
+    ) {
+        companion object {
+            fun from(page: CursorPage<DiaryView>) = FeedResponse(
+                items = page.items.map { DiaryResponse.from(it) },
+                paging = page.paging,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/learner/language/interfaces/diary/DiaryLikeController.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/diary/DiaryLikeController.kt
@@ -1,0 +1,28 @@
+package com.learner.language.interfaces.diary
+
+import com.learner.language.application.diary.DiaryLikeFacade
+import com.learner.language.system.login.LoginUser
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/diaries")
+class DiaryLikeController(
+    private val diaryLikeFacade: DiaryLikeFacade,
+) {
+
+    @PostMapping("/{diaryId}/like")
+    fun toggle(
+        @LoginUser userId: Long,
+        @PathVariable diaryId: Long,
+        @Valid @RequestBody request: DiaryLikeDto.ToggleRequest,
+    ): ResponseEntity<DiaryLikeDto.ToggleResponse> {
+        val result = diaryLikeFacade.setLiked(diaryId, userId, request.liked)
+        return ResponseEntity.ok(DiaryLikeDto.ToggleResponse.from(result))
+    }
+}

--- a/src/main/kotlin/com/learner/language/interfaces/diary/DiaryLikeDto.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/diary/DiaryLikeDto.kt
@@ -1,0 +1,26 @@
+package com.learner.language.interfaces.diary
+
+import com.learner.language.application.diary.DiaryLikeFacade
+import jakarta.validation.constraints.NotNull
+
+object DiaryLikeDto {
+
+    data class ToggleRequest(
+        @field:NotNull
+        val liked: Boolean,
+    )
+
+    data class ToggleResponse(
+        val diaryId: Long,
+        val likeCount: Int,
+        val userLiked: Boolean,
+    ) {
+        companion object {
+            fun from(result: DiaryLikeFacade.Result) = ToggleResponse(
+                diaryId = result.diaryId,
+                likeCount = result.likeCount,
+                userLiked = result.userLiked,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/learner/language/interfaces/user/UserApiController.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/user/UserApiController.kt
@@ -6,6 +6,7 @@ import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -53,5 +54,14 @@ class UserApiController(
         val response = UserDto.InfoResponse(userInfo)
 
         return ResponseEntity.status(HttpStatus.OK).body(response)
+    }
+
+    @GetMapping("/{userId}")
+    fun getUserProfile(
+        @LoginUser viewerId: Long,
+        @PathVariable userId: Long,
+    ): ResponseEntity<UserDto.PublicProfileResponse> {
+        val info = userFacade.retrievePublicProfile(viewerId, userId)
+        return ResponseEntity.ok(UserDto.PublicProfileResponse(info))
     }
 }

--- a/src/main/kotlin/com/learner/language/interfaces/user/UserDto.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/user/UserDto.kt
@@ -1,8 +1,10 @@
 package com.learner.language.interfaces.user
 
+import com.learner.language.domain.user.PublicUserProfileInfo
 import com.learner.language.domain.user.UserCommand
 import com.learner.language.domain.user.UserInfo
 import jakarta.validation.constraints.NotEmpty
+import java.time.Instant
 
 class UserDto {
     data class RegisterRequest(
@@ -44,12 +46,50 @@ class UserDto {
     }
 
     data class InfoResponse(
+        val id: Long,
+        val userId: Long,
         val username: String,
-        val email: String
+        val email: String,
+        val avatarUrl: String?,
+        val provider: String,
+        val createdAt: Instant,
     ) {
         constructor(userInfo: UserInfo): this(
+            id = userInfo.id,
+            userId = userInfo.id,
             username = userInfo.username,
-            email = userInfo.email
+            email = userInfo.email,
+            avatarUrl = userInfo.avatarUrl,
+            provider = userInfo.provider,
+            createdAt = userInfo.createdAt,
+        )
+    }
+
+    data class PublicProfileResponse(
+        val id: Long,
+        val userId: Long,
+        val username: String,
+        val avatarUrl: String?,
+        val provider: String,
+        val createdAt: Instant,
+        val diaryCount: Long,
+        val followerCount: Long,
+        val followingCount: Long,
+        val isFollowing: Boolean,
+        val bio: String?,
+    ) {
+        constructor(info: PublicUserProfileInfo) : this(
+            id = info.id,
+            userId = info.userId,
+            username = info.username,
+            avatarUrl = info.avatarUrl,
+            provider = info.provider,
+            createdAt = info.createdAt,
+            diaryCount = info.diaryCount,
+            followerCount = info.followerCount,
+            followingCount = info.followingCount,
+            isFollowing = info.isFollowing,
+            bio = info.bio,
         )
     }
 

--- a/src/main/kotlin/com/learner/language/interfaces/validation/DiaryValidationController.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/validation/DiaryValidationController.kt
@@ -1,0 +1,35 @@
+package com.learner.language.interfaces.validation
+
+import com.learner.language.application.validation.DiaryValidationFacade
+import com.learner.language.system.login.LoginUser
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/diaries/validate")
+class DiaryValidationController(
+    private val validationFacade: DiaryValidationFacade,
+) {
+
+    @PostMapping
+    fun validate(
+        @LoginUser userId: Long,
+        @Valid @RequestBody request: DiaryValidationDto.ValidateRequest,
+    ): ResponseEntity<DiaryValidationDto.ValidationResponse> {
+        val result = validationFacade.validate(request.lines)
+        return ResponseEntity.ok(DiaryValidationDto.ValidationResponse.from(result))
+    }
+
+    @PostMapping("/line")
+    fun validateLine(
+        @LoginUser userId: Long,
+        @Valid @RequestBody request: DiaryValidationDto.ValidateLineRequest,
+    ): ResponseEntity<DiaryValidationDto.LineResponse> {
+        val result = validationFacade.validateLine(request.lineIndex, request.text)
+        return ResponseEntity.ok(DiaryValidationDto.LineResponse.from(result))
+    }
+}

--- a/src/main/kotlin/com/learner/language/interfaces/validation/DiaryValidationDto.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/validation/DiaryValidationDto.kt
@@ -1,0 +1,53 @@
+package com.learner.language.interfaces.validation
+
+import com.learner.language.application.validation.DiaryValidationResult
+import com.learner.language.application.validation.LineValidation
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+object DiaryValidationDto {
+
+    data class ValidateRequest(
+        @field:NotNull
+        @field:Size(min = 3, max = 3, message = "lines는 정확히 3개여야 합니다.")
+        val lines: List<@NotEmpty String> = emptyList(),
+    )
+
+    data class ValidateLineRequest(
+        @field:NotNull
+        val lineIndex: Int,
+        @field:NotEmpty
+        val text: String,
+    )
+
+    data class LineResponse(
+        val lineIndex: Int,
+        val originalText: String,
+        val status: String,
+        val message: String,
+        val suggestion: String?,
+    ) {
+        companion object {
+            fun from(validation: LineValidation) = LineResponse(
+                lineIndex = validation.lineIndex,
+                originalText = validation.originalText,
+                status = validation.status.apiValue(),
+                message = validation.message,
+                suggestion = validation.suggestion,
+            )
+        }
+    }
+
+    data class ValidationResponse(
+        val validationId: String,
+        val lines: List<LineResponse>,
+    ) {
+        companion object {
+            fun from(result: DiaryValidationResult) = ValidationResponse(
+                validationId = result.validationId,
+                lines = result.lines.map { LineResponse.from(it) },
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/learner/language/system/config/AuthPropertiesConfig.kt
+++ b/src/main/kotlin/com/learner/language/system/config/AuthPropertiesConfig.kt
@@ -1,0 +1,18 @@
+package com.learner.language.system.config
+
+import com.learner.language.infrastructure.auth.AuthAppProperties
+import com.learner.language.infrastructure.auth.AuthCodeProperties
+import com.learner.language.infrastructure.auth.OAuthProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling
+@EnableConfigurationProperties(
+    OAuthProperties::class,
+    AuthCodeProperties::class,
+    AuthAppProperties::class,
+    CorsProperties::class,
+)
+class AuthPropertiesConfig

--- a/src/main/kotlin/com/learner/language/system/config/CorsProperties.kt
+++ b/src/main/kotlin/com/learner/language/system/config/CorsProperties.kt
@@ -1,0 +1,13 @@
+package com.learner.language.system.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "app.cors")
+data class CorsProperties(
+    val allowedOrigins: List<String> = listOf("http://localhost:3000"),
+    val allowedMethods: List<String> = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"),
+    val allowedHeaders: List<String> = listOf("Authorization", "Content-Type"),
+    val allowCredentials: Boolean = false,
+    val exposedHeaders: List<String> = listOf("Authorization"),
+    val maxAge: Long = 3600L,
+)

--- a/src/main/kotlin/com/learner/language/system/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/learner/language/system/config/SecurityConfig.kt
@@ -14,6 +14,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import com.learner.language.system.config.CorsProperties
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 import org.springframework.web.filter.CorsFilter
@@ -76,6 +77,9 @@ class SecurityConfig(
                     "/api/v1/users",
                     "/api/v1/users/validation-email",
                     "/api/v1/users/validation-number",
+                    "/api/v1/auth/oauth/*/start",
+                    "/api/v1/auth/oauth/*/callback",
+                    "/api/v1/auth/exchange",
                     "/swagger-ui/**",
                     "/swagger-ui/index.html",
                     "/v3/api-docs/**",
@@ -90,14 +94,14 @@ class SecurityConfig(
     }
 
     @Bean
-    fun corsFilter(): CorsFilter {
+    fun corsFilter(corsProperties: CorsProperties): CorsFilter {
         val config = CorsConfiguration().apply {
-            allowedOriginPatterns = listOf("*")
-            allowCredentials = false
-            allowedMethods = listOf("*")
-            allowedHeaders = listOf("*")
-            exposedHeaders = listOf("Authorization")
-            maxAge = 3600L
+            allowedOrigins = corsProperties.allowedOrigins
+            allowCredentials = corsProperties.allowCredentials
+            allowedMethods = corsProperties.allowedMethods
+            allowedHeaders = corsProperties.allowedHeaders
+            exposedHeaders = corsProperties.exposedHeaders
+            maxAge = corsProperties.maxAge
         }
         val source = UrlBasedCorsConfigurationSource()
         source.registerCorsConfiguration("/**", config)

--- a/src/main/kotlin/com/learner/language/system/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/learner/language/system/config/SecurityConfig.kt
@@ -80,6 +80,7 @@ class SecurityConfig(
                     "/api/v1/auth/oauth/*/start",
                     "/api/v1/auth/oauth/*/callback",
                     "/api/v1/auth/exchange",
+                    "/api/v1/auth/refresh",
                     "/swagger-ui/**",
                     "/swagger-ui/index.html",
                     "/v3/api-docs/**",

--- a/src/main/kotlin/com/learner/language/system/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/learner/language/system/exception/ErrorCode.kt
@@ -30,6 +30,20 @@ enum class ErrorCode(
     OAUTH_EMAIL_CONFLICT("AF605"), // 동일 이메일이 다른 가입 경로로 이미 존재
     OAUTH_CODE_INVALID("AF606"), // exchange 시 code 가 없거나 만료/소비됨
     OAUTH_CONFIGURATION_MISSING("AF607"), // properties 누락 (startup 검증 실패)
+    // Diary
+    DIARY_NOT_FOUND("AF701"),
+    DIARY_FORBIDDEN("AF702"),
+    INVALID_LINE_COUNT("AF703"),
+    INVALID_LINE_LENGTH("AF704"),
+    INVALID_TAG_COUNT("AF705"),
+    INVALID_TAG_LENGTH("AF706"),
+    // Comment
+    COMMENT_NOT_FOUND("AF721"),
+    COMMENT_TOO_LONG("AF722"),
+    COMMENT_FORBIDDEN("AF723"),
+    // AI validation
+    VALIDATION_FAILED("AF731"),
+    VALIDATION_TIMEOUT("AF732"),
     // 500
     SERVICE_UNAVAILABLE("AF998"), // 서비스 이용 불가
     INTERNAL_SERVER_ERROR("AF999"); // 서버 내부 에러

--- a/src/main/kotlin/com/learner/language/system/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/learner/language/system/exception/ErrorCode.kt
@@ -22,6 +22,14 @@ enum class ErrorCode(
     // 409
     ALREADY_EXISTS("AF901"), // 이미 존재하는 리소스
     CONCURRENCY("AF902"), // 선착순 마감
+    // OAuth
+    OAUTH_AUTHORIZATION_FAILED("AF601"), // provider 가 error 반환 또는 code 누락
+    OAUTH_STATE_INVALID("AF602"), // state 쿠키 누락 또는 불일치
+    OAUTH_PROVIDER_ERROR("AF603"), // provider 호출 실패 (5xx, 타임아웃, 4xx)
+    OAUTH_EMAIL_REQUIRED("AF604"), // provider 가 email scope 미동의
+    OAUTH_EMAIL_CONFLICT("AF605"), // 동일 이메일이 다른 가입 경로로 이미 존재
+    OAUTH_CODE_INVALID("AF606"), // exchange 시 code 가 없거나 만료/소비됨
+    OAUTH_CONFIGURATION_MISSING("AF607"), // properties 누락 (startup 검증 실패)
     // 500
     SERVICE_UNAVAILABLE("AF998"), // 서비스 이용 불가
     INTERNAL_SERVER_ERROR("AF999"); // 서버 내부 에러

--- a/src/main/kotlin/com/learner/language/system/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/learner/language/system/exception/ErrorCode.kt
@@ -44,6 +44,8 @@ enum class ErrorCode(
     // AI validation
     VALIDATION_FAILED("AF731"),
     VALIDATION_TIMEOUT("AF732"),
+    // Refresh/logout
+    REFRESH_TOKEN_INVALID("AF741"),
     // 500
     SERVICE_UNAVAILABLE("AF998"), // 서비스 이용 불가
     INTERNAL_SERVER_ERROR("AF999"); // 서버 내부 에러

--- a/src/main/kotlin/com/learner/language/system/exception/ExceptionResponse.kt
+++ b/src/main/kotlin/com/learner/language/system/exception/ExceptionResponse.kt
@@ -1,6 +1,9 @@
 package com.learner.language.system.exception
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class ExceptionResponse(
-    val message: String
-) {
-}
+    val message: String,
+    val code: String? = null,
+)

--- a/src/main/kotlin/com/learner/language/system/exception/ForbiddenException.kt
+++ b/src/main/kotlin/com/learner/language/system/exception/ForbiddenException.kt
@@ -1,6 +1,6 @@
 package com.learner.language.system.exception
 
-open class BadRequestException(
+open class ForbiddenException(
     errorCode: ErrorCode,
     message: String,
     publicCode: String = errorCode.name,

--- a/src/main/kotlin/com/learner/language/system/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/learner/language/system/exception/GlobalExceptionHandler.kt
@@ -1,5 +1,7 @@
 package com.learner.language.system.exception
 
+import com.learner.language.application.validation.ValidationFailedException
+import com.learner.language.application.validation.ValidationTimeoutException
 import com.learner.language.domain.auth.OAuthAuthenticationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -44,6 +46,16 @@ class GlobalExceptionHandler {
     fun unprocessableEx(e: UnprocessableEntityException): ResponseEntity<ExceptionResponse> =
         ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
             .body(ExceptionResponse(e.message ?: "요청을 처리할 수 없습니다.", e.publicCode))
+
+    @ExceptionHandler(ValidationTimeoutException::class)
+    fun validationTimeout(e: ValidationTimeoutException): ResponseEntity<ExceptionResponse> =
+        ResponseEntity.status(HttpStatus.GATEWAY_TIMEOUT)
+            .body(ExceptionResponse(e.message ?: "AI 응답 지연", e.publicCode))
+
+    @ExceptionHandler(ValidationFailedException::class)
+    fun validationFailed(e: ValidationFailedException): ResponseEntity<ExceptionResponse> =
+        ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ExceptionResponse(e.message ?: "AI 검증 실패", e.publicCode))
 
     @ExceptionHandler(LanguageException::class)
     fun languageEx(e: LanguageException): ResponseEntity<ExceptionResponse> =

--- a/src/main/kotlin/com/learner/language/system/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/learner/language/system/exception/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package com.learner.language.system.exception
 
+import com.learner.language.application.auth.RefreshTokenInvalidException
 import com.learner.language.application.validation.ValidationFailedException
 import com.learner.language.application.validation.ValidationTimeoutException
 import com.learner.language.domain.auth.OAuthAuthenticationException
@@ -56,6 +57,11 @@ class GlobalExceptionHandler {
     fun validationFailed(e: ValidationFailedException): ResponseEntity<ExceptionResponse> =
         ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(ExceptionResponse(e.message ?: "AI 검증 실패", e.publicCode))
+
+    @ExceptionHandler(RefreshTokenInvalidException::class)
+    fun refreshTokenInvalid(e: RefreshTokenInvalidException): ResponseEntity<ExceptionResponse> =
+        ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body(ExceptionResponse(e.message ?: "refresh token 이 유효하지 않습니다.", e.publicCode))
 
     @ExceptionHandler(LanguageException::class)
     fun languageEx(e: LanguageException): ResponseEntity<ExceptionResponse> =

--- a/src/main/kotlin/com/learner/language/system/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/learner/language/system/exception/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package com.learner.language.system.exception
 
+import com.learner.language.domain.auth.OAuthAuthenticationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -10,15 +11,47 @@ class GlobalExceptionHandler {
     @ExceptionHandler(BadRequestException::class)
     fun badRequestException(e: BadRequestException): ResponseEntity<ExceptionResponse> =
         ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ExceptionResponse(e.message ?: "잘못된 요청입니다"))
+            .body(ExceptionResponse(e.message ?: "잘못된 요청입니다", e.publicCode))
 
-    @ExceptionHandler(RuntimeException::class)
-    fun runtimeEx(e: RuntimeException): ResponseEntity<ExceptionResponse> =
-        ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(ExceptionResponse("예측하지 못한 예외가 발생하였습니다. ${e.message}"))
+    @ExceptionHandler(ServiceUnavailableException::class)
+    fun serviceUnavailableException(e: ServiceUnavailableException): ResponseEntity<ExceptionResponse> =
+        ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+            .body(ExceptionResponse(e.message ?: "외부 서비스 호출에 실패했습니다", e.publicCode))
+
+    @ExceptionHandler(OAuthAuthenticationException::class)
+    fun oauthAuthenticationException(e: OAuthAuthenticationException): ResponseEntity<ExceptionResponse> {
+        val status = when (e.oauthErrorCode) {
+            ErrorCode.OAUTH_EMAIL_CONFLICT -> HttpStatus.CONFLICT
+            ErrorCode.OAUTH_PROVIDER_ERROR -> HttpStatus.BAD_GATEWAY
+            ErrorCode.OAUTH_CONFIGURATION_MISSING -> HttpStatus.INTERNAL_SERVER_ERROR
+            else -> HttpStatus.BAD_REQUEST
+        }
+        return ResponseEntity.status(status)
+            .body(ExceptionResponse(e.message ?: e.oauthErrorCode.name, e.publicCode))
+    }
 
     @ExceptionHandler(NotFoundException::class)
     fun notFoundEx(e: NotFoundException): ResponseEntity<ExceptionResponse> =
         ResponseEntity.status(HttpStatus.NOT_FOUND)
-            .body(ExceptionResponse(e.message ?: "리소스를 찾을 수 없습니다."))
+            .body(ExceptionResponse(e.message ?: "리소스를 찾을 수 없습니다.", e.publicCode))
+
+    @ExceptionHandler(ForbiddenException::class)
+    fun forbiddenEx(e: ForbiddenException): ResponseEntity<ExceptionResponse> =
+        ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body(ExceptionResponse(e.message ?: "접근 권한이 없습니다.", e.publicCode))
+
+    @ExceptionHandler(UnprocessableEntityException::class)
+    fun unprocessableEx(e: UnprocessableEntityException): ResponseEntity<ExceptionResponse> =
+        ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+            .body(ExceptionResponse(e.message ?: "요청을 처리할 수 없습니다.", e.publicCode))
+
+    @ExceptionHandler(LanguageException::class)
+    fun languageEx(e: LanguageException): ResponseEntity<ExceptionResponse> =
+        ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ExceptionResponse(e.message ?: "잘못된 요청입니다", e.publicCode))
+
+    @ExceptionHandler(RuntimeException::class)
+    fun runtimeEx(e: RuntimeException): ResponseEntity<ExceptionResponse> =
+        ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ExceptionResponse("예측하지 못한 예외가 발생하였습니다. ${e.message}", "INTERNAL_SERVER_ERROR"))
 }

--- a/src/main/kotlin/com/learner/language/system/exception/LanguageException.kt
+++ b/src/main/kotlin/com/learner/language/system/exception/LanguageException.kt
@@ -2,8 +2,9 @@ package com.learner.language.system.exception
 
 open class LanguageException(
     private val errorCode: ErrorCode,
-    message: String
-) : RuntimeException(message){
+    message: String,
+    open val publicCode: String = errorCode.name,
+) : RuntimeException(message) {
 
     fun getErrorCode(): String {
         return errorCode.getValue()

--- a/src/main/kotlin/com/learner/language/system/exception/NotFoundException.kt
+++ b/src/main/kotlin/com/learner/language/system/exception/NotFoundException.kt
@@ -2,6 +2,6 @@ package com.learner.language.system.exception
 
 open class NotFoundException(
     errorCode: ErrorCode,
-    message: String
-) : LanguageException(errorCode, message) {
-}
+    message: String,
+    publicCode: String = errorCode.name,
+) : LanguageException(errorCode, message, publicCode)

--- a/src/main/kotlin/com/learner/language/system/exception/UnprocessableEntityException.kt
+++ b/src/main/kotlin/com/learner/language/system/exception/UnprocessableEntityException.kt
@@ -1,6 +1,6 @@
 package com.learner.language.system.exception
 
-open class BadRequestException(
+open class UnprocessableEntityException(
     errorCode: ErrorCode,
     message: String,
     publicCode: String = errorCode.name,

--- a/src/main/kotlin/com/learner/language/system/security/OAuthStateCookieManager.kt
+++ b/src/main/kotlin/com/learner/language/system/security/OAuthStateCookieManager.kt
@@ -1,0 +1,46 @@
+package com.learner.language.system.security
+
+import com.learner.language.domain.user.AuthProvider
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+
+@Component
+class OAuthStateCookieManager {
+
+    fun set(response: HttpServletResponse, provider: AuthProvider, value: String) {
+        val cookie = Cookie(cookieName(provider), value).apply {
+            isHttpOnly = true
+            secure = true
+            path = "/"
+            maxAge = MAX_AGE_SECONDS
+            setAttribute("SameSite", "Lax")
+        }
+        response.addCookie(cookie)
+    }
+
+    fun get(request: HttpServletRequest, provider: AuthProvider): String? {
+        val name = cookieName(provider)
+        return request.cookies?.firstOrNull { it.name == name }?.value
+    }
+
+    fun clear(response: HttpServletResponse, provider: AuthProvider) {
+        val cookie = Cookie(cookieName(provider), "").apply {
+            isHttpOnly = true
+            secure = true
+            path = "/"
+            maxAge = 0
+            setAttribute("SameSite", "Lax")
+        }
+        response.addCookie(cookie)
+    }
+
+    private fun cookieName(provider: AuthProvider): String =
+        "$COOKIE_PREFIX${provider.name}"
+
+    companion object {
+        private const val COOKIE_PREFIX = "LANGUAGE_OAUTH_STATE_"
+        private const val MAX_AGE_SECONDS = 5 * 60
+    }
+}

--- a/src/main/kotlin/com/learner/language/system/security/UserDetailsImpl.kt
+++ b/src/main/kotlin/com/learner/language/system/security/UserDetailsImpl.kt
@@ -19,7 +19,7 @@ class UserDetailsImpl(
         return listOf(SimpleGrantedAuthority(authority))
     }
 
-    override fun getPassword(): String = user.password.password
+    override fun getPassword(): String = user.password?.password ?: ""
 
     override fun getUsername(): String = user.username
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,3 +57,40 @@ spring:
 ##  audio:
 ##    storage:
 ##      path: /app/audio-storage
+
+app:
+  frontend-base-url: ${FRONTEND_BASE_URL:http://localhost:3000}
+  backend-base-url: ${BACKEND_BASE_URL:http://localhost:8080}
+  chatbot:
+    base-url: http://chatbot-service:8000
+    transcript-path: /chatbot/api/v1/transcript
+    connect-timeout: 2s
+    read-timeout: 5s
+  auth:
+    auth-code:
+      ttl: PT60S
+    oauth:
+      kakao:
+        client-id: ${KAKAO_CLIENT_ID:}
+        client-secret: ${KAKAO_CLIENT_SECRET:}
+        redirect-uri: ${app.backend-base-url}/api/v1/auth/oauth/kakao/callback
+        authorize-uri: https://kauth.kakao.com/oauth/authorize
+        token-uri: https://kauth.kakao.com/oauth/token
+        user-info-uri: https://kapi.kakao.com/v2/user/me
+        scope: account_email profile_nickname
+      naver:
+        client-id: ${NAVER_CLIENT_ID:}
+        client-secret: ${NAVER_CLIENT_SECRET:}
+        redirect-uri: ${app.backend-base-url}/api/v1/auth/oauth/naver/callback
+        authorize-uri: https://nid.naver.com/oauth2.0/authorize
+        token-uri: https://nid.naver.com/oauth2.0/token
+        user-info-uri: https://openapi.naver.com/v1/nid/me
+        scope: name email
+      google:
+        client-id: ${GOOGLE_CLIENT_ID:}
+        client-secret: ${GOOGLE_CLIENT_SECRET:}
+        redirect-uri: ${app.backend-base-url}/api/v1/auth/oauth/google/callback
+        authorize-uri: https://accounts.google.com/o/oauth2/v2/auth
+        token-uri: https://oauth2.googleapis.com/token
+        user-info-uri: https://openidconnect.googleapis.com/v1/userinfo
+        scope: openid email profile

--- a/src/main/resources/db/migration/V2__add_user_oauth_columns.sql
+++ b/src/main/resources/db/migration/V2__add_user_oauth_columns.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `user`
+    ADD COLUMN provider VARCHAR(20) NOT NULL DEFAULT 'LOCAL',
+    ADD COLUMN provider_external_id VARCHAR(100) NULL;
+
+ALTER TABLE `user`
+    ADD CONSTRAINT uk_user_provider_external UNIQUE (provider, provider_external_id);

--- a/src/main/resources/db/migration/V3__add_diary_tables.sql
+++ b/src/main/resources/db/migration/V3__add_diary_tables.sql
@@ -1,0 +1,31 @@
+CREATE TABLE diary (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    line_1 VARCHAR(200) NOT NULL,
+    line_2 VARCHAR(200) NOT NULL,
+    line_3 VARCHAR(200) NOT NULL,
+    is_public BIT NOT NULL DEFAULT b'1',
+    like_count INT NOT NULL DEFAULT 0,
+    comment_count INT NOT NULL DEFAULT 0,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT FK_diary_user FOREIGN KEY (user_id) REFERENCES `user`(id)
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_diary_public_created ON diary (is_public, created_at, id);
+CREATE INDEX idx_diary_user_created ON diary (user_id, created_at, id);
+CREATE INDEX idx_diary_like_count ON diary (is_public, like_count, id);
+
+CREATE TABLE diary_tag (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    diary_id BIGINT NOT NULL,
+    tag VARCHAR(32) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT FK_diary_tag_diary FOREIGN KEY (diary_id) REFERENCES diary(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_diary_tag_diary ON diary_tag (diary_id);
+CREATE INDEX idx_diary_tag_tag ON diary_tag (tag, diary_id);

--- a/src/main/resources/db/migration/V4__add_diary_like_table.sql
+++ b/src/main/resources/db/migration/V4__add_diary_like_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE diary_like (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    diary_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_diary_like UNIQUE (diary_id, user_id),
+    CONSTRAINT FK_diary_like_diary FOREIGN KEY (diary_id) REFERENCES diary(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_diary_like_user ON diary_like (user_id, diary_id);

--- a/src/main/resources/db/migration/V5__add_comment_tables.sql
+++ b/src/main/resources/db/migration/V5__add_comment_tables.sql
@@ -1,0 +1,29 @@
+CREATE TABLE diary_comment (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    diary_id BIGINT NOT NULL,
+    author_user_id BIGINT NOT NULL,
+    text VARCHAR(500) NOT NULL,
+    parent_comment_id BIGINT NULL,
+    like_count INT NOT NULL DEFAULT 0,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT FK_diary_comment_diary FOREIGN KEY (diary_id) REFERENCES diary(id) ON DELETE CASCADE,
+    CONSTRAINT FK_diary_comment_author FOREIGN KEY (author_user_id) REFERENCES `user`(id)
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_comment_diary_created ON diary_comment (diary_id, created_at, id);
+CREATE INDEX idx_comment_parent ON diary_comment (parent_comment_id);
+
+CREATE TABLE comment_like (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    comment_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_comment_like UNIQUE (comment_id, user_id),
+    CONSTRAINT FK_comment_like_comment FOREIGN KEY (comment_id) REFERENCES diary_comment(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_comment_like_user ON comment_like (user_id, comment_id);


### PR DESCRIPTION
## Summary

`docs/prd/backend_api_request.md`에 정의된 v1 백엔드 API를 단일 feature 브랜치로 구현합니다.

- OAuth 소셜 로그인 (Kakao / Naver / Google) — ADR-0001 Code Exchange 패턴
- 3줄 일기 도메인 (피드 / 상세 / 작성 / 삭제 / 내 일기) + cursor 페이지네이션
- 좋아요 토글 (diary + comment) — 멱등 설정
- 댓글 목록/작성/삭제, 대댓글 지원
- AI 3줄 검증 (OpenAI ChatClient 구조화 응답)
- /users/me 확장, /users/{id} 공개 프로필
- /auth/refresh 토큰 재발급
- 공통: 에러 응답에 code 필드, camelCase, CORS origin 명시, cursor 유틸
- 빌드 툴체인 Java 21로 통일

프론트 계약(`docs/prd/backend_api_request.md`)과 정확히 일치하는 JSON shape을 반환합니다.

## 커밋 / 마일스톤 매핑

| 커밋 | 마일스톤 | 범위 |
|---|---|---|
| C0 `feat(auth): implement OAuth social login and v1 API common infrastructure` | M0 + M1 | OAuth(3 providers) + Java 21 + 에러/CORS/pagination 공통 기반 |
| C1 `feat(diary): add three-line diary APIs with like, comments and AI validation` | M2 + M3 + M4 + M5 | Diary CRUD, Like, Comment, AI validation + Flyway V3/V4/V5 |
| C2 `feat(user): expand /users/me and add public profile endpoint` | M6 | /users/me shape 확장 + /users/{id} |
| C3 `feat(auth): add refresh token endpoint` | M7 | /auth/refresh |

## 주요 변경

### DB 마이그레이션 (Flyway)
- `V2` : user 테이블에 `provider`, `provider_external_id` 추가
- `V3` : `diary` (3 line columns, denormalized like/comment count) + `diary_tag`
- `V4` : `diary_like` (unique key)
- `V5` : `diary_comment` (parent_comment_id) + `comment_like`

### 신규 엔드포인트

| Path | Method | 인증 |
|---|---|---|
| `/api/v1/auth/oauth/{provider}/start` | GET | No |
| `/api/v1/auth/oauth/{provider}/callback` | GET | No |
| `/api/v1/auth/exchange` | POST | No |
| `/api/v1/auth/refresh` | POST | No |
| `/api/v1/auth/logout` | POST | Yes |
| `/api/v1/diaries/feed` | GET | Yes |
| `/api/v1/diaries/me` | GET | Yes |
| `/api/v1/diaries/{id}` | GET / DELETE | Yes |
| `/api/v1/diaries` | POST | Yes |
| `/api/v1/diaries/{id}/like` | POST | Yes |
| `/api/v1/diaries/{id}/comments` | GET / POST | Yes |
| `/api/v1/comments/{id}/like` | POST | Yes |
| `/api/v1/comments/{id}` | DELETE | Yes |
| `/api/v1/diaries/validate` | POST | Yes |
| `/api/v1/diaries/validate/line` | POST | Yes |
| `/api/v1/users/me` | GET | Yes (shape 확장) |
| `/api/v1/users/{userId}` | GET | Yes (신규) |

### 설계 결정 (PRD Open Questions 대응)
- `lines` 저장: **3개 컬럼** (`line_1`, `line_2`, `line_3`) — v1 고정 3줄
- `accentTone`: `diaryId % 5` 해시 — 저장 공간 절약
- `voiceParticipantCount`: 상수 0 (Screen 3 미구현)
- `followerCount`/`followingCount`/`isFollowing`: 0/false stub (follow 도메인 후속)
- tags: 별도 테이블 (`diary_tag`) — 태그 필터 인덱싱
- trending 정렬: `like_count DESC` 단순 구현
- cursor 포맷: base64(`createdAt_epoch_millis:id`) opaque 문자열
- Comment 삭제: hard delete, 대댓글은 orphan 허용 (graceful degradation on UI)

## ⚠️ 운영 반영 체크리스트

- **Provider 콘솔 redirect URI**: `/api/v1/auth/oauth/{kakao|naver|google}/callback` 로 등록 필요 (로컬 `http://localhost:8080/...` 및 운영 `https://jamoai.app/...`)
- **`application-local.yml` / `.env.local`은 secret 포함**이라 이 PR에서 제외했습니다. 운영/로컬에서는 기존처럼 로컬 유지 + 환경변수/application-local.yml 을 통해 주입하면 됩니다. `.gitignore`에 추가하는 후속 PR이 필요할 수 있습니다.
- Flyway V2~V5 가 순차 적용되어야 합니다. 기존 V1 baseline 이후 적용 순서 확인.
- AI 검증은 Spring AI ChatClient(OpenAI gpt-4o-mini)를 재사용합니다. 별도 모델 설정 불필요.

## Test Plan

- [ ] `./gradlew compileKotlin` 통과 (로컬 확인 완료)
- [ ] V2~V5 마이그레이션이 로컬 MySQL 에 적용되어 테이블 생성 확인
- [ ] OAuth 3 provider 흐름 모두 브라우저에서 로그인 → `/auth/exchange` 성공
- [ ] `POST /diaries` → 피드 조회 → 상세 → 좋아요 → 댓글 순으로 curl 회귀
- [ ] `POST /diaries/validate` 로 status = ok/suggestion/error 확인
- [ ] `/users/me` 응답 shape 가 `backend_api_request.md §3.1` 와 정확 일치
- [ ] `/users/{id}` 응답이 §3.2 와 일치
- [ ] `/auth/refresh` 로 access/refresh 재발급 후 이후 Bearer 호출 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)