### PR TITLE
chore(git): ignore local secret files (.env.local, application-local.yml)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,13 @@ build/
 !**/src/resoucres/
 
 !**/src/main/resources/application.yml
-!**/src/main/resources/application-local.yml
 !**/src/main/resources/application-prod.yml
 !**/src/main/resources/application-test.yml
 !**/src/test/resources/application-test.yml
 *.yml
 .env
+.env.*
+!.env.example
 
 ### STS ###
 .apt_generated


### PR DESCRIPTION
## Summary

`application-local.yml`과 `.env.local`은 JWT / OpenAI / OAuth (Kakao·Naver·Google) client secret을 평문으로 담고 있는 로컬 전용 설정 파일입니다. 현재 `.gitignore`는 `application-local.yml`을 오히려 allowlist 예외로 허용하고 있어 실수로 커밋되면 secret이 원격에 노출됩니다. (실제로 PR #39 푸시 시 GitHub secret scanning 이 두 파일의 키를 차단했습니다.)

## 변경

```diff
 !**/src/main/resources/application.yml
-!**/src/main/resources/application-local.yml
 !**/src/main/resources/application-prod.yml
 ...
 .env
+.env.*
+!.env.example
```

- `application-local.yml`의 allowlist 예외 제거 → 상단 `*.yml` 규칙에 의해 기본 ignore
- `.env.*` 패턴으로 모든 로컬 env 변형 차단 (`.env.local`, 향후 `.env.production` 등)
- `.env.example`은 템플릿이므로 allowlist 예외로 tracking 유지

## 검증

`git check-ignore -v` 로 확인:

```
.gitignore:13:*.yml    src/main/resources/application-local.yml
.gitignore:15:.env.*   .env.local
```

`.env.example`은 check-ignore 출력 없음 → 정상적으로 tracked 상태 유지.

## Test plan
- [ ] 기존 로컬 `application-local.yml` / `.env.local` 파일이 `git status` 에 더 이상 나타나지 않는지 확인
- [ ] `.env.example` 은 여전히 tracked 상태인지 확인
- [ ] 팀원들이 pull 받은 후 로컬 dev 기동이 정상 (이미 untracked이므로 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)