### PR TITLE
fix(diarychat): move base path to /api/v1/diary-chatrooms (Spring ambiguous mapping startup fix)

### DIFF
--- a/docs/prd/backend_api_request.md
+++ b/docs/prd/backend_api_request.md
@@ -594,6 +594,7 @@ Screen 3은 **"각자 녹음 → STT → 텍스트로 합류하는 음성 기반
 
 ### 7.0.1 구현 메모 / spec 대비 diff
 
+- **베이스 path 변경 (필수)** — spec 의 `/chatrooms` 는 기존 페르소나 채팅 도메인(`ChatRoomApiController`, `/api/v1/chatrooms`)이 이미 사용 중이라 충돌. **본 도메인은 `/api/v1/diary-chatrooms`** 로 마운트한다. 즉 `POST /api/v1/diary-chatrooms`, `GET /api/v1/diary-chatrooms/{roomId}`, `.../messages`, `.../messages/poll` 등 spec 의 모든 `/chatrooms/...` 를 `/diary-chatrooms/...` 로 치환.
 - **events 저장 모델 (구현 변경)** — spec은 events 를 별도 데이터로 다루지만, 단일 `after={messageId}` cursor 정합성을 위해 백엔드 내부에서는 `diary_chat_message` 테이블에 `source='system' + event_type` 형태로 함께 저장한다. 폴링 응답 시 `source` 로 분리해서 `items` / `events` 두 필드로 변환. **응답 shape 은 spec 그대로**.
 - **AI 토글 기본값** — spec은 `aiAssistantEnabled` 기본 false. 사용자(=PRD owner) 결정으로 **default true** 로 변경 (방 생성 시 자동 ON). 방장이 끌 수 있음.
 - **AI 식별자** — `author.userId = -1`, `username = "Jamo AI"` 합성 author 로 응답 (별도 필드 없이 author 객체에 담김).

--- a/src/main/kotlin/com/learner/language/interfaces/diarychat/DiaryChatMessageController.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/diarychat/DiaryChatMessageController.kt
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/api/v1/chatrooms/{roomId}/messages")
+@RequestMapping("/api/v1/diary-chatrooms/{roomId}/messages")
 class DiaryChatMessageController(
     private val facade: DiaryChatMessageFacade,
 ) {

--- a/src/main/kotlin/com/learner/language/interfaces/diarychat/DiaryChatPollingController.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/diarychat/DiaryChatPollingController.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.context.request.async.DeferredResult
 
 @RestController
-@RequestMapping("/api/v1/chatrooms/{roomId}/messages")
+@RequestMapping("/api/v1/diary-chatrooms/{roomId}/messages")
 class DiaryChatPollingController(
     private val facade: DiaryChatPollingFacade,
 ) {

--- a/src/main/kotlin/com/learner/language/interfaces/diarychat/DiaryChatRoomController.kt
+++ b/src/main/kotlin/com/learner/language/interfaces/diarychat/DiaryChatRoomController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/api/v1/chatrooms")
+@RequestMapping("/api/v1/diary-chatrooms")
 class DiaryChatRoomController(
     private val facade: DiaryChatRoomFacade,
 ) {


### PR DESCRIPTION
## Summary

PR #41(diary chatroom v1)이 머지된 직후 앱 부팅 시 다음 에러가 발생했습니다:

\`\`\`
Caused by: org.springframework.beans.factory.BeanCreationException:
  Error creating bean with name 'requestMappingHandlerMapping' ...
  Ambiguous mapping. Cannot map 'diaryChatRoomController' method
  ... DiaryChatRoomController#create(...)
  to {POST [/api/v1/chatrooms]}: There is already 'chatRoomApiController' bean method
\`\`\`

기존 페르소나 챗봇 도메인의 \`ChatRoomApiController\`가 \`/api/v1/chatrooms\` prefix를 이미 점유 중이라 PRD §7 spec 그대로 매핑 시 charter가 충돌합니다.

## 변경

- \`DiaryChatRoomController\`, \`DiaryChatMessageController\`, \`DiaryChatPollingController\` 의 base path 를 \`/api/v1/chatrooms\` → \`/api/v1/diary-chatrooms\` 로 이동
- API request/response shape 변경 없음. **base path 1단어만 변경**
- PRD §7.0.1 에 spec 대비 deviation 으로 기록 (프론트가 contract base 업데이트 필요)

## 새 endpoint 매핑

| 변경 전 | 변경 후 |
|---|---|
| \`POST /api/v1/chatrooms\` | \`POST /api/v1/diary-chatrooms\` |
| \`GET /api/v1/chatrooms/{id}\` | \`GET /api/v1/diary-chatrooms/{id}\` |
| \`GET /api/v1/chatrooms/{id}/participants\` | \`GET /api/v1/diary-chatrooms/{id}/participants\` |
| \`POST /api/v1/chatrooms/{id}/join\` | \`POST /api/v1/diary-chatrooms/{id}/join\` |
| \`POST /api/v1/chatrooms/{id}/leave\` | \`POST /api/v1/diary-chatrooms/{id}/leave\` |
| \`POST /api/v1/chatrooms/{id}/ai-toggle\` | \`POST /api/v1/diary-chatrooms/{id}/ai-toggle\` |
| \`GET/POST /api/v1/chatrooms/{id}/messages\` | \`GET/POST /api/v1/diary-chatrooms/{id}/messages\` |
| \`GET /api/v1/chatrooms/{id}/messages/poll\` | \`GET /api/v1/diary-chatrooms/{id}/messages/poll\` |

## Test plan

- [ ] 앱이 정상 부팅되고 ambiguous mapping 에러 없음
- [ ] \`POST /api/v1/diary-chatrooms\` 가 PR #41 의 동작과 동일하게 신규 방 + 웰컴 메시지 트리거
- [ ] 기존 \`/api/v1/chatrooms\` (페르소나 챗봇) 엔드포인트는 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)