### PR TITLE
feat(ai): add transcript-aware chat prompts and TranscriptChatRequest

### DIFF
--- a/src/main/kotlin/com/learner/language/domain/ai/AiChatCommand.kt
+++ b/src/main/kotlin/com/learner/language/domain/ai/AiChatCommand.kt
@@ -33,6 +33,17 @@ class AiChatCommand {
             }
         }
 
+        data class TranscriptChatRequest(
+            val history: String,
+            val transcriptContext: String,
+            override val personaType: PersonaType,
+            override val input: String = history,
+        ) : AiRequest(input, personaType) {
+            override fun createPrompt(aiPromptService: AiPromptService): Prompt {
+                return aiPromptService.createPrompt(this)
+            }
+        }
+
         data class ChatRoomNameRequest(
             override val input: String,
             override val personaType: PersonaType,

--- a/src/main/kotlin/com/learner/language/domain/ai/AiChatService.kt
+++ b/src/main/kotlin/com/learner/language/domain/ai/AiChatService.kt
@@ -76,6 +76,25 @@ class AiChatService(
         return chatMessage
     }
 
+    fun generateTranscriptChat(
+        command: ChatCommand.Generate,
+        user: User,
+        chatRoom: ChatRoom,
+        chatHistory: String,
+        transcriptContext: String,
+        nextSequence: Int
+    ): ChatMessage {
+        val aiRequest = AiChatCommand.AiRequest.TranscriptChatRequest(
+            history = chatHistory,
+            transcriptContext = transcriptContext,
+            personaType = command.personaType
+        )
+        val response = generate(aiRequest)
+        logger.info { "ai answer response generateTranscriptChat: ${response.response}" }
+
+        return command.toEntity(user, chatRoom, response.response, nextSequence)
+    }
+
     fun greetingChat(personaType: PersonaType, user: User, chatRoom: ChatRoom, chatHistory: String, nextSequence: Int): ChatMessage {
         val aiRequest = AiChatCommand.AiRequest.ChatRequest(
             input = chatHistory,
@@ -86,6 +105,31 @@ class AiChatService(
         val chatMessage = ChatMessage(user = user, chatRoom = chatRoom, message = response.response, senderType = SenderType.AI, sequence = nextSequence)
 
         return chatMessage
+    }
+
+    fun greetingTranscriptChat(
+        personaType: PersonaType,
+        user: User,
+        chatRoom: ChatRoom,
+        chatHistory: String,
+        transcriptContext: String,
+        nextSequence: Int
+    ): ChatMessage {
+        val aiRequest = AiChatCommand.AiRequest.TranscriptChatRequest(
+            history = chatHistory,
+            transcriptContext = transcriptContext,
+            personaType = personaType
+        )
+        val response = generateGreeting(aiRequest)
+        logger.info { "ai answer response greetingTranscriptChat: ${response.response}" }
+
+        return ChatMessage(
+            user = user,
+            chatRoom = chatRoom,
+            message = response.response,
+            senderType = SenderType.AI,
+            sequence = nextSequence
+        )
     }
 
     fun phraseChat(

--- a/src/main/kotlin/com/learner/language/domain/ai/AiPromptService.kt
+++ b/src/main/kotlin/com/learner/language/domain/ai/AiPromptService.kt
@@ -16,6 +16,8 @@ class AiPromptService(
     private val systemFeedbackResource: Resource,
     @Value("classpath:prompts/system-chat-message-0112-gpt.st") // gpt
     private val systemChatResource: Resource,
+    @Value("classpath:prompts/system-transcript-chat-message.st")
+    private val systemTranscriptChatResource: Resource,
     @Value("classpath:prompts/system-phrase-message.st")
     private val systemPhraseResource: Resource,
     @Value("classpath:prompts/system-chatroomname-message.st")
@@ -24,6 +26,8 @@ class AiPromptService(
     private val userFeedbackResource: Resource,
     @Value("classpath:prompts/user-chat-message.st")
     private val userChatResource: Resource,
+    @Value("classpath:prompts/user-transcript-chat-message.st")
+    private val userTranscriptChatResource: Resource,
     @Value("classpath:prompts/user-phrase-message.st")
     private val userPhraseResource: Resource,
     @Value("classpath:prompts/user-chatroomname-message.st")
@@ -58,6 +62,15 @@ class AiPromptService(
         )
     }
 
+    private fun createUserTranscriptChatMessage(history: String, transcriptContext: String): Message {
+        return PromptTemplate(userTranscriptChatResource).createMessage(
+            mapOf(
+                "history" to history,
+                "transcript_context" to transcriptContext,
+            )
+        )
+    }
+
     private fun createUserChatRoomNameMessage(message: String): Message {
         return PromptTemplate(userChatRoomNameResource).createMessage(
             mapOf(
@@ -77,6 +90,13 @@ class AiPromptService(
 
     private fun createSystemPhraseMessage(personaType: PersonaType): Message =
         SystemPromptTemplate(systemPhraseResource).createMessage(
+            mapOf(
+                "persona" to toKoreanPersona(personaType)
+            )
+        )
+
+    private fun createSystemTranscriptChatMessage(personaType: PersonaType): Message =
+        SystemPromptTemplate(systemTranscriptChatResource).createMessage(
             mapOf(
                 "persona" to toKoreanPersona(personaType)
             )
@@ -112,6 +132,18 @@ class AiPromptService(
                             aiChatRequest.input
                         ),
                         createSystemChatMessage(prompt)
+                    )
+                )
+            }
+
+            is AiChatCommand.AiRequest.TranscriptChatRequest -> {
+                Prompt(
+                    listOf(
+                        createUserTranscriptChatMessage(
+                            aiChatRequest.history,
+                            aiChatRequest.transcriptContext
+                        ),
+                        createSystemTranscriptChatMessage(aiChatRequest.personaType)
                     )
                 )
             }

--- a/src/main/resources/prompts/system-transcript-chat-message.st
+++ b/src/main/resources/prompts/system-transcript-chat-message.st
@@ -1,0 +1,16 @@
+Role:
+You are a Korean native-speaking AI conversation partner named "자모".
+You speak in a natural Korean tone with this persona style: {persona}
+
+Primary Goal:
+- Talk with the user based on the provided video transcript context.
+- Use the transcript as the main source of truth for topic, expressions, and situation.
+
+Rules:
+- Stay grounded in the transcript context and recent conversation history.
+- If the user asks about a line, expression, or situation from the video, explain it clearly in Korean.
+- If the transcript does not support a claim, say it is uncertain instead of making it up.
+- Keep the conversation natural, not overly academic.
+- You may help the user practice Korean expressions that appear in the transcript.
+- Do not prefix responses with your name.
+- Output Korean only.

--- a/src/main/resources/prompts/user-transcript-chat-message.st
+++ b/src/main/resources/prompts/user-transcript-chat-message.st
@@ -1,0 +1,9 @@
+Transcript Context:
+"""
+{transcript_context}
+"""
+
+Conversation History:
+"""
+{history}
+"""


### PR DESCRIPTION
## Summary
- `AiChatCommand.AiRequest.TranscriptChatRequest` 추가 (conversation history + video transcript context 운반)
- `AiChatService.greetingTranscriptChat` / `generateTranscriptChat` 추가 — transcript 컨텍스트를 받아 AI 응답을 persist
- `AiPromptService`가 두 개의 신규 prompt 리소스를 로드하고 persona/history/transcript_context placeholder를 렌더링
- 신규 프롬프트 리소스
  - `prompts/system-transcript-chat-message.st` — \"자모\" 페르소나, transcript에 grounded
  - `prompts/user-transcript-chat-message.st` — `transcript_context`/`history` placeholder만 포함

## Notes
- 시크릿 없음 (프롬프트는 일반 가이드 텍스트)
- 이 PR 단독으로는 호출자가 없음. `chat` 도메인 PR에서 `ChatServiceImpl`이 transcript 분기를 추가하면서 사용

## Test plan
- [ ] `./gradlew compileKotlin compileTestKotlin` 통과
- [ ] AiPromptService 단위 테스트가 있다면 통과
- [ ] 후속 chat 도메인 PR과 함께 머지 후 video transcript chatroom flow가 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)